### PR TITLE
src/ResultPrinter/HTML.php: Use Unique Test Signatures

### DIFF
--- a/src/ResultPrinter/HTML.php
+++ b/src/ResultPrinter/HTML.php
@@ -123,7 +123,7 @@ class HTML extends CodeceptionResultPrinter
         );
 
         $failures = '';
-        $name = Descriptor::getTestSignature($test);
+        $name = Descriptor::getTestSignatureUnique($test);
         if (isset($this->failures[$name])) {
             $failTemplate = new \Text_Template(
                 $this->templatePath . 'fail.html'
@@ -236,7 +236,7 @@ class HTML extends CodeceptionResultPrinter
      */
     public function addError(\PHPUnit\Framework\Test $test, \Throwable $e, float $time) : void
     {
-        $this->failures[Descriptor::getTestSignature($test)][] = $this->cleanMessage($e);
+        $this->failures[Descriptor::getTestSignatureUnique($test)][] = $this->cleanMessage($e);
         parent::addError($test, $e, $time);
     }
 
@@ -249,10 +249,10 @@ class HTML extends CodeceptionResultPrinter
      */
     public function addFailure(\PHPUnit\Framework\Test $test, \PHPUnit\Framework\AssertionFailedError $e, float $time) : void
     {
-        $this->failures[Descriptor::getTestSignature($test)][] = $this->cleanMessage($e);
+        $this->failures[Descriptor::getTestSignatureUnique($test)][] = $this->cleanMessage($e);
         parent::addFailure($test, $e, $time);
     }
-    
+
     /**
      * Starts test
      *
@@ -260,7 +260,7 @@ class HTML extends CodeceptionResultPrinter
      */
     public function startTest(\PHPUnit\Framework\Test $test):void
     {
-        $name = Descriptor::getTestSignature($test);
+        $name = Descriptor::getTestSignatureUnique($test);
         if (isset($this->failures[$name])) {
             // test failed in before hook
             return;


### PR DESCRIPTION
Fixes #4

- replace use of `Descriptor::getTestSignature` with `Descriptor::getTestSignatureUnique`


## Output (using same example as #4 )

<img width="906" alt="screen shot 2018-03-01 at 14 52 18" src="https://user-images.githubusercontent.com/13963952/36851110-625472ce-1d60-11e8-88fb-c04f05ec5997.png">