### PR TITLE
#15/html report expectation failed exception

### DIFF
--- a/src/ResultPrinter/HTML.php
+++ b/src/ResultPrinter/HTML.php
@@ -297,7 +297,7 @@ class HTML extends CodeceptionResultPrinter
     private function cleanMessage($exception)
     {
         $msg = $exception->getMessage();
-        if ($exception instanceof \PHPUnit\Framework\AssertionFailedError && $exception->getComparisonFailure()) {
+        if ($exception instanceof \PHPUnit\Framework\ExpectationFailedException && $exception->getComparisonFailure()) {
             $msg .= $exception->getComparisonFailure()->getDiff();
         }
         $msg = str_replace(['<info>','</info>','<bold>','</bold>'], ['','','',''], $msg);


### PR DESCRIPTION
Changes instance of exception to one with `getComparisonFailure` method.
Fixes #15

# Output using same example as #15:

```
$ codecept run acceptance --html
Codeception PHP Testing Framework v2.4.1
Powered by PHPUnit 7.0.2 by Sebastian Bergmann and contributors.

Acceptance Tests (3) ---------------------------------------------------------------------------------------------------------------
✖ FailsCest: Failed assert (0.03s)
✔ FailsCest: Passed assert (0.00s)
✖ FailsCest: Fail hard (0.00s)
------------------------------------------------------------------------------------------------------------------------------------


Time: 161 ms, Memory: 8.00MB

There were 2 failures:

---------
1) FailsCest: Failed assert
 Test  tests/acceptance/FailsCest.php:failedAssert
 Step  Assert equals true,false
 Fail  Failed asserting that false matches expected true.

Scenario Steps:

 1. $I->assertEquals(true,false) at tests/acceptance/FailsCest.php:8


---------
2) FailsCest: Fail hard
 Test  tests/acceptance/FailsCest.php:failHard
 Step  Fail "Hard fail"
 Fail  Hard fail

Scenario Steps:

 1. $I->fail("Hard fail") at tests/acceptance/FailsCest.php:18


FAILURES!
Tests: 3, Assertions: 3, Failures: 2.
- HTML report generated in file:///Users/Tenz/Repositories/demo/tests/_output/report.html
```