### PR TITLE
Fix issue codeception/codeception#4888 (7.0)

### DIFF
--- a/src/FilterTest.php
+++ b/src/FilterTest.php
@@ -28,6 +28,13 @@ class FilterTest extends \PHPUnit\Runner\Filter\NameFilterIterator
 
         $accepted = preg_match($this->filter, $name, $matches);
 
+        // This fix the issue when an invalid dataprovider method generate a warning
+        // See issue https://github.com/Codeception/Codeception/issues/4888
+        if($test instanceof \PHPUnit\Framework\WarningTestCase) {
+            $message = $test->getMessage();
+            $accepted = preg_match($this->filter, $message, $matches);
+        }
+
         if ($accepted && isset($this->filterMax)) {
             $set = end($matches);
             $accepted = $set >= $this->filterMin && $set <= $this->filterMax;


### PR DESCRIPTION
Fix issue when a filter is applied on a unit test with an invalid dataprovider (codeception/codeception#4888)