### PR TITLE
Improve support of PHPUnit warning status (7.0)

### DIFF
--- a/src/Listener.php
+++ b/src/Listener.php
@@ -53,6 +53,8 @@ class Listener implements \PHPUnit\Framework\TestListener
     // This method was added in PHPUnit 6
     public function addWarning(\PHPUnit\Framework\Test $test, \PHPUnit\Framework\Warning $e, float $time) : void
     {
+        $this->unsuccessfulTests[] = spl_object_hash($test);
+        $this->fire(Events::TEST_WARNING, new FailEvent($test, $time, $e));
     }
 
     public function addIncompleteTest(\PHPUnit\Framework\Test $test, \Throwable $e, float $time) : void

--- a/src/ResultPrinter.php
+++ b/src/ResultPrinter.php
@@ -34,6 +34,19 @@ class ResultPrinter extends \PHPUnit\Util\TestDox\ResultPrinter
     }
 
     /**
+     * A warning occurred.
+     *
+     * @param \PHPUnit\Framework\Test $test
+     * @param \PHPUnit\Framework\Warning $e
+     * @param float $time
+     */
+    public function addWarning(\PHPUnit\Framework\Test $test, \PHPUnit\Framework\Warning $e, float $time): void
+    {
+        $this->testStatus = \PHPUnit\Runner\BaseTestRunner::STATUS_WARNING;
+        $this->warned++;
+    }
+
+    /**
      * Incomplete test.
      *
      * @param \PHPUnit\Framework\Test $test

--- a/src/ResultPrinter/UI.php
+++ b/src/ResultPrinter/UI.php
@@ -83,6 +83,11 @@ class UI extends \PHPUnit\TextUI\ResultPrinter
         $this->lastTestFailed = true;
     }
 
+    public function addWarning(\PHPUnit\Framework\Test $test, \PHPUnit\Framework\Warning $e, float $time) : void
+    {
+        $this->lastTestFailed = true;
+    }
+
     public function addIncompleteTest(\PHPUnit\Framework\Test $test, \Throwable $e, float $time) : void
     {
         $this->lastTestFailed = true;


### PR DESCRIPTION
Better support of PHPUnit warning status:
- support PHPUnit addWarning()
- display 'W' instead of success for warning test cases