### PR TITLE
Fixed Report compatibility with PHPU7

### DIFF
--- a/src/ResultPrinter/Report.php
+++ b/src/ResultPrinter/Report.php
@@ -41,7 +41,7 @@ class Report extends ResultPrinter implements ConsolePrinter
         $this->write($line . "\n");
     }
 
-    protected function endRun()
+    protected function endRun() : void
     {
         $this->write("\nCodeception Results\n");
         $this->write(sprintf(
@@ -57,8 +57,8 @@ class Report extends ResultPrinter implements ConsolePrinter
     {
     }
 
-    public function write($buffer)
+    public function write($buffer) : void
     {
-
+		parent::write($buffer);
     }
 }


### PR DESCRIPTION
Using codeception 2.3.8 I could run "codecept run unit --report" with no problems, like:

```
PS C:\Users\bxo\killmeafterwards2> .\vendor\bin\codecept run unit --report
Codeception PHP Testing Framework v2.3.8
Powered by PHPUnit 6.5.7 by Sebastian Bergmann and contributors.
PrimeiroCest: Try to test..................................................FAIL
PrimeiroCest: Try to tes2t.................................................Ok
```


Using the newest 2.4.1 version, the following error comes up:

```
Codeception PHP Testing Framework v2.4.1
Powered by PHPUnit 7.0.3 by Sebastian Bergmann and contributors.
PHP Fatal error:  Declaration of Codeception\PHPUnit\ResultPrinter\Report::endRun() must be compatible with PHPUnit\Util\TestDox\ResultPrinter::endRun(): void in C:\Users\bxo\killmeafterwards2\vendor\codeception\phpunit-wrapper\src\ResultPrinter\Report.php on line 9
PHP Stack trace:
PHP   1. {main}() C:\Users\bxo\killmeafterwards2\vendor\codeception\codeception\codecept:0
PHP   2. Codeception\Application->run() C:\Users\bxo\killmeafterwards2\vendor\codeception\codeception\codecept:42
PHP   3. Codeception\Application->run() C:\Users\bxo\killmeafterwards2\vendor\codeception\codeception\src\Codeception\Application.php:108
PHP   4. Codeception\Application->doRun() C:\Users\bxo\killmeafterwards2\vendor\symfony\console\Application.php:143
PHP   5. Codeception\Application->doRunCommand() C:\Users\bxo\killmeafterwards2\vendor\symfony\console\Application.php:241
PHP   6. Codeception\Command\Run->run() C:\Users\bxo\killmeafterwards2\vendor\symfony\console\Application.php:865
PHP   7. Codeception\Command\Run->execute() C:\Users\bxo\killmeafterwards2\vendor\symfony\console\Command\Command.php:252
PHP   8. Codeception\Command\Run->runSuites() C:\Users\bxo\killmeafterwards2\vendor\codeception\codeception\src\Codeception\Command\Run.php:361
PHP   9. Codeception\Codecept->run() C:\Users\bxo\killmeafterwards2\vendor\codeception\codeception\src\Codeception\Command\Run.php:466
PHP  10. Codeception\Codecept->runSuite() C:\Users\bxo\killmeafterwards2\vendor\codeception\codeception\src\Codeception\Codecept.php:158
PHP  11. Codeception\SuiteManager->run() C:\Users\bxo\killmeafterwards2\vendor\codeception\codeception\src\Codeception\Codecept.php:189
PHP  12. Codeception\PHPUnit\Runner->doEnhancedRun() C:\Users\bxo\killmeafterwards2\vendor\codeception\codeception\src\Codeception\SuiteManager.php:157
PHP  13. Codeception\PHPUnit\Runner->applyReporters() C:\Users\bxo\killmeafterwards2\vendor\codeception\phpunit-wrapper\src\Runner.php:99
PHP  14. Codeception\PHPUnit\Runner->instantiateReporter() C:\Users\bxo\killmeafterwards2\vendor\codeception\phpunit-wrapper\src\Runner.php:139
PHP  15. ReflectionClass->__construct() C:\Users\bxo\killmeafterwards2\vendor\codeception\phpunit-wrapper\src\Runner.php:182
PHP  16. spl_autoload_call() C:\Users\bxo\killmeafterwards2\vendor\codeception\phpunit-wrapper\src\Runner.php:182
PHP  17. Composer\Autoload\ClassLoader->loadClass() C:\Users\bxo\killmeafterwards2\vendor\codeception\phpunit-wrapper\src\Runner.php:182
PHP  18. Composer\Autoload\includeFile() C:\Users\bxo\killmeafterwards2\vendor\composer\ClassLoader.php:322
PHP  19. include() C:\Users\bxo\killmeafterwards2\vendor\composer\ClassLoader.php:444
```

This PR is meant to fix it. Thanks!

