### PR TITLE
Fix ResultPrinter compatibility with PHPU7 patch-2

### DIFF
--- a/src/ResultPrinter/UI.php
+++ b/src/ResultPrinter/UI.php
@@ -20,7 +20,7 @@ class UI extends \PHPUnit\TextUI\ResultPrinter
         $this->dispatcher = $dispatcher;
     }
 
-    protected function printDefect(\PHPUnit\Framework\TestFailure $defect, $count): void
+    protected function printDefect(\PHPUnit\Framework\TestFailure $defect, int $count): void
     {
         $this->write("\n---------\n");
         $this->dispatcher->dispatch(


### PR DESCRIPTION
Fixes #24
Warning: Declaration of Codeception\PHPUnit\ResultPrinter\UI::printDefect(PHPUnit\Framework\TestFailure $defect, $count): void should be compatible with PHPUnit\TextUI\ResultPrinter::printDefect(PHPUnit\Framework\TestFailure $defect, int $count): void