### PR TITLE
Require phpunit 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^7.1",
         "phpunit/php-code-coverage": "^6.0",
         "sebastian/comparator": "^2.0",
         "sebastian/diff": "^3.0"


### PR DESCRIPTION
Because #23 and #25 make wrapper incompatible with phpunit 7.0