### PR TITLE
Report:write compatibility fix

### DIFF
--- a/src/ConsolePrinter.php
+++ b/src/ConsolePrinter.php
@@ -9,7 +9,7 @@ namespace Codeception\PHPUnit;
  */
 interface ConsolePrinter
 {
-    public function write($buffer);
+    public function write(string $buffer);
 
     public function printResult(\PHPUnit\Framework\TestResult $result);
 }

--- a/src/ResultPrinter/Report.php
+++ b/src/ResultPrinter/Report.php
@@ -57,8 +57,8 @@ class Report extends ResultPrinter implements ConsolePrinter
     {
     }
 
-    public function write($buffer) : void
+    public function write(string $buffer) : void
     {
-		parent::write($buffer);
+        parent::write($buffer);
     }
 }


### PR DESCRIPTION
Compatibility with PHPUnit 7.0+
Error thrown: 
> Declaration of Codeception\PHPUnit\ResultPrinter\Report::write($buffer): void should be compatible with PHPUnit\Util\Printer::write(string $buffer): void

