### PR TITLE
Fix return type

### DIFF
--- a/src/Constraint/Page.php
+++ b/src/Constraint/Page.php
@@ -44,7 +44,7 @@ class Page extends \PHPUnit\Framework\Constraint\Constraint
      *
      * @return string
      */
-    public function toString()
+    public function toString() : string
     {
         return sprintf(
             'contains "%s"',


### PR DESCRIPTION
```
PHP Fatal error:  Declaration of Codeception\PHPUnit\Constraint\Page::toString() must be compatible with PHPUnit\Framework\SelfDescribing::toString(): string in vendor/codeception/phpunit-wrapper/src/Constraint/Page.php on line 79
```