### PR TITLE
PHP Syntax Fixes

### DIFF
--- a/src/Constraint/CrawlerNot.php
+++ b/src/Constraint/CrawlerNot.php
@@ -31,7 +31,7 @@ class CrawlerNot extends Crawler
         );
     }
 
-    public function toString()
+    public function toString() : string
     {
         if ($this->string) {
             return 'that contains text "' . $this->string . '"';

--- a/src/Constraint/JsonContains.php
+++ b/src/Constraint/JsonContains.php
@@ -56,7 +56,7 @@ class JsonContains extends \PHPUnit\Framework\Constraint\Constraint
      *
      * @return string
      */
-    public function toString()
+    public function toString() : string
     {
         //unused
         return '';

--- a/src/Constraint/JsonType.php
+++ b/src/Constraint/JsonType.php
@@ -50,7 +50,7 @@ class JsonType extends \PHPUnit\Framework\Constraint\Constraint
      *
      * @return string
      */
-    public function toString()
+    public function toString() : string
     {
         //unused
         return '';

--- a/src/Constraint/WebDriverNot.php
+++ b/src/Constraint/WebDriverNot.php
@@ -32,7 +32,7 @@ class WebDriverNot extends WebDriver
         );
     }
 
-    public function toString()
+    public function toString() : string
     {
         if ($this->string) {
             return 'that contains text "' . $this->string . '"';

--- a/src/ResultPrinter/UI.php
+++ b/src/ResultPrinter/UI.php
@@ -37,7 +37,7 @@ class UI extends \PHPUnit\TextUI\ResultPrinter
         $this->write($defect->getExceptionAsString());
         $this->writeNewLine();
 
-        $stackTrace = \PHPUnit\Util\Filter::getFilteredStacktrace($defect->thrownException(), false);
+        $stackTrace = \PHPUnit\Util\Filter::getFilteredStacktrace($defect->thrownException());
 
         foreach ($stackTrace as $i => $frame) {
             if (!isset($frame['file'])) {


### PR DESCRIPTION
After running across #28, I did some more digging and hit a few more instances of missing `string` return types for toString overrides. I installed phpstan to see if I could catch anything else, and that's how I found the `getFilteredStackTrace` call. However, most of the issues phpstan is reporting are due to this repo referencing code from Codeception/Codeception, so I opted to not include phpstan in this PR.