### PR TITLE
Fix warning "Array to string conversion"

### DIFF
--- a/src/phpunit5-loggers.php
+++ b/src/phpunit5-loggers.php
@@ -560,7 +560,7 @@ namespace PHPUnit\Util\Log {
                         "not ok %d - %s%s%s\n",
                         $this->testNumber,
                         $prefix != '' ? $prefix . ': ' : '',
-                        \PHPUnit\Util\Test::describe($test),
+                        \PHPUnit\Util\Test::describeAsString($test),
                         $directive != '' ? ' # ' . $directive : ''
                     )
                 );


### PR DESCRIPTION
 if running codecept with --tap option.

For example, run codecept and terminate with ctrl+c
Output:
```
$ bin/codecept run --tap
#!/usr/bin/env php
Codeception PHP Testing Framework v2.4.1
Powered by PHPUnit 7.1.5 by Sebastian Bergmann and contributors.

..................

In ErrorHandler.php line 83:
                              
  Array to string conversion  
                              

run [-o|--override OVERRIDE] [-e|--ext EXT] [--report] [--html [HTML]] [--xml [XML]] [--tap [TAP]] [--json [JSON]] [--colors] [--no-colors] [--silent] [--steps] [-d|--debug] [--coverage [COVERAGE]] [--coverage-html [COVERAGE-HTML]] [--coverage-xml [COVERAGE-XML]] [--coverage-text [COVERAGE-TEXT]] [--coverage-crap4j [COVERAGE-CRAP4J]] [--coverage-phpunit [COVERAGE-PHPUNIT]] [--no-exit] [-g|--group GROUP] [-s|--skip SKIP] [-x|--skip-group SKIP-GROUP] [--env ENV] [-f|--fail-fast] [--no-rebuild] [--] [<suite>] [<test>]

PHP Fatal error:  Uncaught RuntimeException: Command Did Not Finish Properly in vendor/codeception/codeception/src/Codeception/Subscriber/ErrorHandler.php:101
Stack trace:
#0 [internal function]: Codeception\Subscriber\ErrorHandler->shutdownHandler()
#1 {main}
  thrown in vendor/codeception/codeception/src/Codeception/Subscriber/ErrorHandler.php on line 101
PHP Stack trace:
PHP   1. {main}() bin/codecept:0
PHP   2. require() bin/codecept:17
PHP   3. Codeception\Application->run() vendor/codeception/codeception/codecept:42
PHP   4. Codeception\Application->run() vendor/codeception/codeception/src/Codeception/Application.php:108
```