### PR TITLE
Bumped lowest versions of dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
         "codeception/phpunit-wrapper": "*"
     },
     "require": {
-        "phpunit/phpunit": ">=4.8.28 <5.0.0 || >=5.6.3 <7.0",
-        "phpunit/php-code-coverage": ">=2.2.4 <6.0",
-        "sebastian/comparator": ">1.1 <3.0",
+        "phpunit/phpunit": ">=5.7.27 <7.0",
+        "phpunit/php-code-coverage": ">=4.0.4 <6.0",
+        "sebastian/comparator": ">=1.2.4 <3.0",
         "sebastian/diff": ">=1.4 <4.0"
 
     },


### PR DESCRIPTION
Because Codeception no longer supports PHP 5.4