### PR TITLE
Register the SymfonyTestListener with the correct state

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -93,7 +93,10 @@ class Runner extends \PHPUnit\TextUI\TestRunner
 
         if (class_exists('\Symfony\Bridge\PhpUnit\SymfonyTestsListener')) {
             $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : [];
-            $arguments['listeners'][] = new \Symfony\Bridge\PhpUnit\SymfonyTestsListener();
+
+            $listener = new \Symfony\Bridge\PhpUnit\SymfonyTestsListener();
+            $listener->globalListenerDisabled();
+            $arguments['listeners'][] = $listener;
         }
 
         $arguments['listeners'][] = $this->printer;


### PR DESCRIPTION
We don't register the symfony listener as a global listener. So we should make sure we disable the global state.

Without this fix the `@expectedDeprecation` (and `ClockMock`, `DnsMock`, etc) won't work because the internal state of the listener is "-2" aka global listener. With this fix the listener gets the correct state of "0", the same as you would get when registering the listener within the `phpunit.xml` config.