### PR TITLE
Create filebased testsuites in JUnit reports 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 env:
-  CODECEPTION_VERSION: '2.4.x-dev'
+  CODECEPTION_VERSION: 'dev-updated-junit-report-tests'
 
 php:
   - 7.1

--- a/src/Log/JUnit.php
+++ b/src/Log/JUnit.php
@@ -5,13 +5,50 @@ use Codeception\Configuration;
 use Codeception\Test\Interfaces\Reported;
 use Codeception\Test\Test;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestSuite;
 
 class JUnit extends \PHPUnit\Util\Log\JUnit
 {
+    const SUITE_LEVEL = 1;
+    const FILE_LEVEL  = 2;
+
     protected $strictAttributes = ['file', 'name', 'class'];
+
+    private $currentFile;
+    private $currentFileSuite;
 
     public function startTest(\PHPUnit\Framework\Test $test):void
     {
+        if (method_exists($test, 'getFileName') ) {
+            $filename = $test->getFileName();
+        } else {
+            $reflector = new \ReflectionClass($test);
+            $filename = $reflector->getFileName();
+        }
+
+        if ($filename !== $this->currentFile) {
+            if ($this->currentFile !== null) {
+                parent::endTestSuite(new TestSuite());
+            }
+
+            //initialize all values to avoid warnings
+            $this->testSuiteAssertions[self::FILE_LEVEL] = 0;
+            $this->testSuiteTests[self::FILE_LEVEL]      = 0;
+            $this->testSuiteTimes[self::FILE_LEVEL]      = 0;
+            $this->testSuiteErrors[self::FILE_LEVEL]     = 0;
+            $this->testSuiteFailures[self::FILE_LEVEL]   = 0;
+            $this->testSuiteSkipped[self::FILE_LEVEL]    = 0;
+
+            $this->testSuiteLevel = self::FILE_LEVEL;
+
+            $this->currentFile = $filename;
+            $this->currentFileSuite = $this->document->createElement('testsuite');
+            $this->currentFileSuite->setAttribute('file', $filename);
+
+            $this->testSuites[self::SUITE_LEVEL]->appendChild($this->currentFileSuite);
+            $this->testSuites[self::FILE_LEVEL] = $this->currentFileSuite;
+        }
+
         if (!$test instanceof Reported) {
             parent::startTest($test);
             return;
@@ -31,7 +68,7 @@ class JUnit extends \PHPUnit\Util\Log\JUnit
 
     public function endTest(\PHPUnit\Framework\Test $test, float $time):void
     {
-        if ($this->currentTestCase !== null and $test instanceof Test) {
+        if ($this->currentTestCase !== null && $test instanceof Test) {
             $numAssertions = $test->getNumAssertions();
             $this->testSuiteAssertions[$this->testSuiteLevel] += $numAssertions;
 
@@ -46,7 +83,7 @@ class JUnit extends \PHPUnit\Util\Log\JUnit
             return;
         }
 
-        // since PhpUnit 7.4.0, parent::endTest ignores tests that aren't instances of TestCase
+        // In PhpUnit 7.4.*, parent::endTest ignores tests that aren't instances of TestCase
         // so I copied this code from PhpUnit 7.3.5
 
         $this->currentTestCase->setAttribute(
@@ -59,5 +96,21 @@ class JUnit extends \PHPUnit\Util\Log\JUnit
         $this->testSuiteTests[$this->testSuiteLevel]++;
         $this->testSuiteTimes[$this->testSuiteLevel] += $time;
         $this->currentTestCase = null;
+    }
+
+    /**
+     * Cleans the mess caused by test suite manipulation in startTest
+     */
+    public function endTestSuite(TestSuite $suite): void
+    {
+        if ($suite->getName()) {
+            if ($this->currentFile) {
+                //close last file in the test suite
+                parent::endTestSuite(new TestSuite());
+                $this->currentFile = null;
+            }
+            $this->testSuiteLevel = self::SUITE_LEVEL;
+        }
+        parent::endTestSuite($suite);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Codeception/Codeception/issues/5004

Example of report after making this change:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="dummy" tests="6" assertions="3" errors="0" failures="0" skipped="0" time="0.328235">
    <testsuite file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/FileExistsCept.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.119059">
      <testcase name="FileExists" file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/FileExistsCept.php" assertions="1" time="0.119059"/>
    </testsuite>
    <testsuite file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/AnotherCest.php" tests="2" assertions="0" errors="0" failures="0" skipped="0" time="0.078635">
      <testcase file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/AnotherCest.php" name="optimistic" class="AnotherCest" assertions="0" time="0.058278"/>
      <testcase file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/AnotherCest.php" name="pessimistic" class="AnotherCest" assertions="0" time="0.020357"/>
    </testsuite>
    <testsuite file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/GroupEventsCest.php" tests="1" assertions="0" errors="0" failures="0" skipped="0" time="0.000562">
      <testcase file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/GroupEventsCest.php" name="countGroupEvents" class="GroupEventsCest" assertions="0" time="0.000562"/>
    </testsuite>
    <testsuite file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/AnotherTest.php" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.129979">
      <testcase name="testFirst" class="AnotherTest" classname="AnotherTest" file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/AnotherTest.php" line="4" assertions="1" time="0.126584"/>
      <testcase name="testSecond" class="AnotherTest" classname="AnotherTest" file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/AnotherTest.php" line="8" assertions="1" time="0.003395"/>
    </testsuite>
  </testsuite>
</testsuites>
```