### PR TITLE
PhpUnit XML reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 env:
-  CODECEPTION_VERSION: '2.4.x-dev'
+  CODECEPTION_VERSION: 'dev-phpunit-xml-reports'
 
 php:
   - 7.1

--- a/src/Log/PhpUnit.php
+++ b/src/Log/PhpUnit.php
@@ -1,0 +1,116 @@
+<?php
+namespace Codeception\PHPUnit\Log;
+
+use Codeception\Configuration;
+use Codeception\Test\Interfaces\Reported;
+use Codeception\Test\Test;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestSuite;
+
+class PhpUnit extends \PHPUnit\Util\Log\JUnit
+{
+    const SUITE_LEVEL = 1;
+    const FILE_LEVEL  = 2;
+
+    protected $strictAttributes = ['file', 'name', 'class'];
+
+    private $currentFile;
+    private $currentFileSuite;
+
+    public function startTest(\PHPUnit\Framework\Test $test):void
+    {
+        if (method_exists($test, 'getFileName') ) {
+            $filename = $test->getFileName();
+        } else {
+            $reflector = new \ReflectionClass($test);
+            $filename = $reflector->getFileName();
+        }
+
+        if ($filename !== $this->currentFile) {
+            if ($this->currentFile !== null) {
+                parent::endTestSuite(new TestSuite());
+            }
+
+            //initialize all values to avoid warnings
+            $this->testSuiteAssertions[self::FILE_LEVEL] = 0;
+            $this->testSuiteTests[self::FILE_LEVEL]      = 0;
+            $this->testSuiteTimes[self::FILE_LEVEL]      = 0;
+            $this->testSuiteErrors[self::FILE_LEVEL]     = 0;
+            $this->testSuiteFailures[self::FILE_LEVEL]   = 0;
+            $this->testSuiteSkipped[self::FILE_LEVEL]    = 0;
+
+            $this->testSuiteLevel = self::FILE_LEVEL;
+
+            $this->currentFile = $filename;
+            $this->currentFileSuite = $this->document->createElement('testsuite');
+            $this->currentFileSuite->setAttribute('file', $filename);
+
+            $this->testSuites[self::SUITE_LEVEL]->appendChild($this->currentFileSuite);
+            $this->testSuites[self::FILE_LEVEL] = $this->currentFileSuite;
+        }
+
+        if (!$test instanceof Reported) {
+            parent::startTest($test);
+            return;
+        }
+
+        $this->currentTestCase = $this->document->createElement('testcase');
+
+        $isStrict = Configuration::config()['settings']['strict_xml'];
+
+        foreach ($test->getReportFields() as $attr => $value) {
+            if ($isStrict and !in_array($attr, $this->strictAttributes)) {
+                continue;
+            }
+            $this->currentTestCase->setAttribute($attr, $value);
+        }
+    }
+
+    public function endTest(\PHPUnit\Framework\Test $test, float $time):void
+    {
+        if ($this->currentTestCase !== null && $test instanceof Test) {
+            $numAssertions = $test->getNumAssertions();
+            $this->testSuiteAssertions[$this->testSuiteLevel] += $numAssertions;
+
+            $this->currentTestCase->setAttribute(
+                'assertions',
+                $numAssertions
+            );
+        }
+
+        if ($test instanceof TestCase) {
+            parent::endTest($test, $time);
+            return;
+        }
+
+        // In PhpUnit 7.4.*, parent::endTest ignores tests that aren't instances of TestCase
+        // so I copied this code from PhpUnit 7.3.5
+
+        $this->currentTestCase->setAttribute(
+            'time',
+            \sprintf('%F', $time)
+        );
+        $this->testSuites[$this->testSuiteLevel]->appendChild(
+            $this->currentTestCase
+        );
+        $this->testSuiteTests[$this->testSuiteLevel]++;
+        $this->testSuiteTimes[$this->testSuiteLevel] += $time;
+        $this->currentTestCase = null;
+    }
+
+    /**
+     * Cleans the mess caused by test suite manipulation in startTest
+     */
+    public function endTestSuite(TestSuite $suite): void
+    {
+        if ($suite->getName()) {
+            if ($this->currentFile) {
+                //close last file in the test suite
+                parent::endTestSuite(new TestSuite());
+                $this->currentFile = null;
+            }
+            $this->testSuiteLevel = self::SUITE_LEVEL;
+        }
+        parent::endTestSuite($suite);
+    }
+}

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -10,11 +10,12 @@ class Runner extends \PHPUnit\TextUI\TestRunner
     public static $persistentListeners = [];
 
     protected $defaultListeners = [
-        'xml'  => false,
-        'html' => false,
-        'tap'  => false,
-        'json' => false,
-        'report' => false
+        'xml'         => false,
+        'phpunit-xml' => false,
+        'html'        => false,
+        'tap'         => false,
+        'json'        => false,
+        'report'      => false
     ];
 
     protected $config = [];
@@ -154,6 +155,13 @@ class Runner extends \PHPUnit\TextUI\TestRunner
             self::$persistentListeners[] = $this->instantiateReporter(
                 'xml',
                 [$this->absolutePath($arguments['xml']), (bool)$arguments['log_incomplete_skipped']]
+            );
+        }
+        if ($arguments['phpunit-xml']) {
+            codecept_debug('Printing PHPUNIT report into ' . $arguments['phpunit-xml']);
+            self::$persistentListeners[] = $this->instantiateReporter(
+                'phpunit-xml',
+                [$this->absolutePath($arguments['phpunit-xml']), (bool)$arguments['log_incomplete_skipped']]
             );
         }
         if ($arguments['tap']) {


### PR DESCRIPTION
Like Junit, but generates testsuite for each test file.

Fixes https://github.com/Codeception/Codeception/issues/5004
Replaces #52 

Example of report :
```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="dummy" tests="6" assertions="3" errors="0" failures="0" skipped="0" time="0.328235">
    <testsuite file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/FileExistsCept.php" tests="1" assertions="1" errors="0" failures="0" skipped="0" time="0.119059">
      <testcase name="FileExists" file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/FileExistsCept.php" assertions="1" time="0.119059"/>
    </testsuite>
    <testsuite file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/AnotherCest.php" tests="2" assertions="0" errors="0" failures="0" skipped="0" time="0.078635">
      <testcase file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/AnotherCest.php" name="optimistic" class="AnotherCest" assertions="0" time="0.058278"/>
      <testcase file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/AnotherCest.php" name="pessimistic" class="AnotherCest" assertions="0" time="0.020357"/>
    </testsuite>
    <testsuite file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/GroupEventsCest.php" tests="1" assertions="0" errors="0" failures="0" skipped="0" time="0.000562">
      <testcase file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/GroupEventsCest.php" name="countGroupEvents" class="GroupEventsCest" assertions="0" time="0.000562"/>
    </testsuite>
    <testsuite file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/AnotherTest.php" tests="2" assertions="2" errors="0" failures="0" skipped="0" time="0.129979">
      <testcase name="testFirst" class="AnotherTest" classname="AnotherTest" file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/AnotherTest.php" line="4" assertions="1" time="0.126584"/>
      <testcase name="testSecond" class="AnotherTest" classname="AnotherTest" file="/c/Projects/phpunit-wrapper/vendor/codeception/codeception/tests/data/claypit/tests/dummy/AnotherTest.php" line="8" assertions="1" time="0.003395"/>
    </testsuite>
  </testsuite>
</testsuites>
```

New command line parameter `--phpunit-xml` will be added to Codeception.