### PR TITLE
PhpUnit 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 
 env:
-  CODECEPTION_VERSION: '2.5.x-dev'
+  CODECEPTION_VERSION: '2.6.x-dev'
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         }
     ],
     "require": {
-        "phpunit/phpunit": ">=7.1 <7.6",
-        "phpunit/php-code-coverage": "^6.0",
+        "phpunit/phpunit": "^8.0",
+        "phpunit/php-code-coverage": "^7.0",
         "sebastian/comparator": "^3.0",
         "sebastian/diff": "^3.0"
     },

--- a/src/Constraint/JsonContains.php
+++ b/src/Constraint/JsonContains.php
@@ -16,7 +16,6 @@ class JsonContains extends \PHPUnit\Framework\Constraint\Constraint
 
     public function __construct(array $expected)
     {
-        parent::__construct();
         $this->expected = $expected;
     }
 

--- a/src/Constraint/JsonType.php
+++ b/src/Constraint/JsonType.php
@@ -12,7 +12,6 @@ class JsonType extends \PHPUnit\Framework\Constraint\Constraint
 
     public function __construct(array $jsonType, $match = true)
     {
-        parent::__construct();
         $this->jsonType = $jsonType;
         $this->match = $match;
     }

--- a/src/Constraint/Page.php
+++ b/src/Constraint/Page.php
@@ -10,7 +10,6 @@ class Page extends \PHPUnit\Framework\Constraint\Constraint
 
     public function __construct($string, $uri = '')
     {
-        parent::__construct();
         $this->string = $this->normalizeText((string)$string);
         $this->uri = $uri;
     }

--- a/src/FilterTest.php
+++ b/src/FilterTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Codeception\PHPUnit;
 
+use Codeception\PHPUnit\NonFinal\NameFilterIterator;
 use Codeception\Test\Descriptor;
 
 /**
@@ -9,7 +10,7 @@ use Codeception\Test\Descriptor;
  * Class FilterTest
  * @package Codeception\PHPUnit
  */
-class FilterTest extends \PHPUnit\Runner\Filter\NameFilterIterator
+class FilterTest extends NameFilterIterator
 {
     public function accept():bool
     {

--- a/src/Log/JUnit.php
+++ b/src/Log/JUnit.php
@@ -6,7 +6,7 @@ use Codeception\Test\Interfaces\Reported;
 use Codeception\Test\Test;
 use PHPUnit\Framework\TestCase;
 
-class JUnit extends \PHPUnit\Util\Log\JUnit
+class JUnit extends \Codeception\PHPUnit\NonFinal\JUnit
 {
     protected $strictAttributes = ['file', 'name', 'class'];
 

--- a/src/Log/PhpUnit.php
+++ b/src/Log/PhpUnit.php
@@ -7,7 +7,7 @@ use Codeception\Test\Test;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
 
-class PhpUnit extends \PHPUnit\Util\Log\JUnit
+class PhpUnit extends \Codeception\PHPUnit\NonFinal\JUnit
 {
     const SUITE_LEVEL = 1;
     const FILE_LEVEL  = 2;

--- a/src/NonFinal/JUnit.php
+++ b/src/NonFinal/JUnit.php
@@ -1,0 +1,436 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Codeception\PHPUnit\NonFinal;
+
+use DOMDocument;
+use DOMElement;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\ExceptionWrapper;
+use PHPUnit\Framework\SelfDescribing;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestFailure;
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Framework\Warning;
+use PHPUnit\Util\Filter;
+use PHPUnit\Util\Printer;
+use PHPUnit\Util\Xml;
+use ReflectionClass;
+use ReflectionException;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+class JUnit extends Printer implements TestListener
+{
+    /**
+     * @var DOMDocument
+     */
+    protected $document;
+
+    /**
+     * @var DOMElement
+     */
+    protected $root;
+
+    /**
+     * @var bool
+     */
+    protected $reportUselessTests = false;
+
+    /**
+     * @var bool
+     */
+    protected $writeDocument = true;
+
+    /**
+     * @var DOMElement[]
+     */
+    protected $testSuites = [];
+
+    /**
+     * @var int[]
+     */
+    protected $testSuiteTests = [0];
+
+    /**
+     * @var int[]
+     */
+    protected $testSuiteAssertions = [0];
+
+    /**
+     * @var int[]
+     */
+    protected $testSuiteErrors = [0];
+
+    /**
+     * @var int[]
+     */
+    protected $testSuiteFailures = [0];
+
+    /**
+     * @var int[]
+     */
+    protected $testSuiteSkipped = [0];
+
+    /**
+     * @var int[]
+     */
+    protected $testSuiteTimes = [0];
+
+    /**
+     * @var int
+     */
+    protected $testSuiteLevel = 0;
+
+    /**
+     * @var DOMElement
+     */
+    protected $currentTestCase;
+
+    /**
+     * Constructor.
+     *
+     * @param null|mixed $out
+     *
+     * @throws \PHPUnit\Framework\Exception
+     */
+    public function __construct($out = null, bool $reportUselessTests = false)
+    {
+        $this->document               = new DOMDocument('1.0', 'UTF-8');
+        $this->document->formatOutput = true;
+
+        $this->root = $this->document->createElement('testsuites');
+        $this->document->appendChild($this->root);
+
+        parent::__construct($out);
+
+        $this->reportUselessTests = $reportUselessTests;
+    }
+
+    /**
+     * Flush buffer and close output.
+     */
+    public function flush(): void
+    {
+        if ($this->writeDocument === true) {
+            $this->write($this->getXML());
+        }
+
+        parent::flush();
+    }
+
+    /**
+     * An error occurred.
+     *
+     * @throws \InvalidArgumentException
+     * @throws ReflectionException
+     */
+    public function addError(Test $test, \Throwable $t, float $time): void
+    {
+        $this->doAddFault($test, $t, $time, 'error');
+        $this->testSuiteErrors[$this->testSuiteLevel]++;
+    }
+
+    /**
+     * A warning occurred.
+     *
+     * @throws \InvalidArgumentException
+     * @throws ReflectionException
+     */
+    public function addWarning(Test $test, Warning $e, float $time): void
+    {
+        $this->doAddFault($test, $e, $time, 'warning');
+        $this->testSuiteFailures[$this->testSuiteLevel]++;
+    }
+
+    /**
+     * A failure occurred.
+     *
+     * @throws \InvalidArgumentException
+     * @throws ReflectionException
+     */
+    public function addFailure(Test $test, AssertionFailedError $e, float $time): void
+    {
+        $this->doAddFault($test, $e, $time, 'failure');
+        $this->testSuiteFailures[$this->testSuiteLevel]++;
+    }
+
+    /**
+     * Incomplete test.
+     */
+    public function addIncompleteTest(Test $test, \Throwable $t, float $time): void
+    {
+        $this->doAddSkipped($test);
+    }
+
+    /**
+     * Risky test.
+     *
+     * @throws ReflectionException
+     */
+    public function addRiskyTest(Test $test, \Throwable $t, float $time): void
+    {
+        if (!$this->reportUselessTests || $this->currentTestCase === null) {
+            return;
+        }
+
+        $error = $this->document->createElement(
+            'error',
+            Xml::prepareString(
+                "Risky Test\n" .
+                Filter::getFilteredStacktrace($t)
+            )
+        );
+
+        $error->setAttribute('type', \get_class($t));
+
+        $this->currentTestCase->appendChild($error);
+
+        $this->testSuiteErrors[$this->testSuiteLevel]++;
+    }
+
+    /**
+     * Skipped test.
+     */
+    public function addSkippedTest(Test $test, \Throwable $t, float $time): void
+    {
+        $this->doAddSkipped($test);
+    }
+
+    /**
+     * A testsuite started.
+     */
+    public function startTestSuite(TestSuite $suite): void
+    {
+        $testSuite = $this->document->createElement('testsuite');
+        $testSuite->setAttribute('name', $suite->getName());
+
+        if (\class_exists($suite->getName(), false)) {
+            try {
+                $class = new ReflectionClass($suite->getName());
+
+                $testSuite->setAttribute('file', $class->getFileName());
+            } catch (ReflectionException $e) {
+            }
+        }
+
+        if ($this->testSuiteLevel > 0) {
+            $this->testSuites[$this->testSuiteLevel]->appendChild($testSuite);
+        } else {
+            $this->root->appendChild($testSuite);
+        }
+
+        $this->testSuiteLevel++;
+        $this->testSuites[$this->testSuiteLevel]          = $testSuite;
+        $this->testSuiteTests[$this->testSuiteLevel]      = 0;
+        $this->testSuiteAssertions[$this->testSuiteLevel] = 0;
+        $this->testSuiteErrors[$this->testSuiteLevel]     = 0;
+        $this->testSuiteFailures[$this->testSuiteLevel]   = 0;
+        $this->testSuiteSkipped[$this->testSuiteLevel]    = 0;
+        $this->testSuiteTimes[$this->testSuiteLevel]      = 0;
+    }
+
+    /**
+     * A testsuite ended.
+     */
+    public function endTestSuite(TestSuite $suite): void
+    {
+        $this->testSuites[$this->testSuiteLevel]->setAttribute(
+            'tests',
+            (string) $this->testSuiteTests[$this->testSuiteLevel]
+        );
+
+        $this->testSuites[$this->testSuiteLevel]->setAttribute(
+            'assertions',
+            (string) $this->testSuiteAssertions[$this->testSuiteLevel]
+        );
+
+        $this->testSuites[$this->testSuiteLevel]->setAttribute(
+            'errors',
+            (string) $this->testSuiteErrors[$this->testSuiteLevel]
+        );
+
+        $this->testSuites[$this->testSuiteLevel]->setAttribute(
+            'failures',
+            (string) $this->testSuiteFailures[$this->testSuiteLevel]
+        );
+
+        $this->testSuites[$this->testSuiteLevel]->setAttribute(
+            'skipped',
+            (string) $this->testSuiteSkipped[$this->testSuiteLevel]
+        );
+
+        $this->testSuites[$this->testSuiteLevel]->setAttribute(
+            'time',
+            \sprintf('%F', $this->testSuiteTimes[$this->testSuiteLevel])
+        );
+
+        if ($this->testSuiteLevel > 1) {
+            $this->testSuiteTests[$this->testSuiteLevel - 1] += $this->testSuiteTests[$this->testSuiteLevel];
+            $this->testSuiteAssertions[$this->testSuiteLevel - 1] += $this->testSuiteAssertions[$this->testSuiteLevel];
+            $this->testSuiteErrors[$this->testSuiteLevel - 1] += $this->testSuiteErrors[$this->testSuiteLevel];
+            $this->testSuiteFailures[$this->testSuiteLevel - 1] += $this->testSuiteFailures[$this->testSuiteLevel];
+            $this->testSuiteSkipped[$this->testSuiteLevel - 1] += $this->testSuiteSkipped[$this->testSuiteLevel];
+            $this->testSuiteTimes[$this->testSuiteLevel - 1] += $this->testSuiteTimes[$this->testSuiteLevel];
+        }
+
+        $this->testSuiteLevel--;
+    }
+
+    /**
+     * A test started.
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws ReflectionException
+     */
+    public function startTest(Test $test): void
+    {
+        $usesDataprovider = false;
+
+        if (\method_exists($test, 'usesDataProvider')) {
+            $usesDataprovider = $test->usesDataProvider();
+        }
+
+        $testCase = $this->document->createElement('testcase');
+        $testCase->setAttribute('name', $test->getName());
+
+        $class      = new ReflectionClass($test);
+        $methodName = $test->getName(!$usesDataprovider);
+
+        if ($class->hasMethod($methodName)) {
+            $method = $class->getMethod($methodName);
+
+            $testCase->setAttribute('class', $class->getName());
+            $testCase->setAttribute('classname', \str_replace('\\', '.', $class->getName()));
+            $testCase->setAttribute('file', $class->getFileName());
+            $testCase->setAttribute('line', (string) $method->getStartLine());
+        }
+
+        $this->currentTestCase = $testCase;
+    }
+
+    /**
+     * A test ended.
+     */
+    public function endTest(Test $test, float $time): void
+    {
+        $numAssertions = 0;
+
+        if (\method_exists($test, 'getNumAssertions')) {
+            $numAssertions = $test->getNumAssertions();
+        }
+
+        $this->testSuiteAssertions[$this->testSuiteLevel] += $numAssertions;
+
+        $this->currentTestCase->setAttribute(
+            'assertions',
+            (string) $numAssertions
+        );
+
+        $this->currentTestCase->setAttribute(
+            'time',
+            \sprintf('%F', $time)
+        );
+
+        $this->testSuites[$this->testSuiteLevel]->appendChild(
+            $this->currentTestCase
+        );
+
+        $this->testSuiteTests[$this->testSuiteLevel]++;
+        $this->testSuiteTimes[$this->testSuiteLevel] += $time;
+
+        $testOutput = '';
+
+        if (\method_exists($test, 'hasOutput') && \method_exists($test, 'getActualOutput')) {
+            $testOutput = $test->hasOutput() ? $test->getActualOutput() : '';
+        }
+
+        if (!empty($testOutput)) {
+            $systemOut = $this->document->createElement(
+                'system-out',
+                Xml::prepareString($testOutput)
+            );
+
+            $this->currentTestCase->appendChild($systemOut);
+        }
+
+        $this->currentTestCase = null;
+    }
+
+    /**
+     * Returns the XML as a string.
+     */
+    public function getXML(): string
+    {
+        return $this->document->saveXML();
+    }
+
+    /**
+     * Enables or disables the writing of the document
+     * in flush().
+     *
+     * This is a "hack" needed for the integration of
+     * PHPUnit with Phing.
+     */
+    public function setWriteDocument(/*bool*/ $flag): void
+    {
+        if (\is_bool($flag)) {
+            $this->writeDocument = $flag;
+        }
+    }
+
+    /**
+     * Method which generalizes addError() and addFailure()
+     *
+     * @throws \InvalidArgumentException
+     * @throws ReflectionException
+     */
+    private function doAddFault(Test $test, \Throwable $t, float $time, $type): void
+    {
+        if ($this->currentTestCase === null) {
+            return;
+        }
+
+        if ($test instanceof SelfDescribing) {
+            $buffer = $test->toString() . "\n";
+        } else {
+            $buffer = '';
+        }
+
+        $buffer .= TestFailure::exceptionToString($t) . "\n" .
+            Filter::getFilteredStacktrace($t);
+
+        $fault = $this->document->createElement(
+            $type,
+            Xml::prepareString($buffer)
+        );
+
+        if ($t instanceof ExceptionWrapper) {
+            $fault->setAttribute('type', $t->getClassName());
+        } else {
+            $fault->setAttribute('type', \get_class($t));
+        }
+
+        $this->currentTestCase->appendChild($fault);
+    }
+
+    private function doAddSkipped(Test $test): void
+    {
+        if ($this->currentTestCase === null) {
+            return;
+        }
+
+        $skipped = $this->document->createElement('skipped');
+        $this->currentTestCase->appendChild($skipped);
+
+        $this->testSuiteSkipped[$this->testSuiteLevel]++;
+    }
+}

--- a/src/NonFinal/NameFilterIterator.php
+++ b/src/NonFinal/NameFilterIterator.php
@@ -1,0 +1,128 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Codeception\PHPUnit\NonFinal;
+
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Framework\WarningTestCase;
+use PHPUnit\Util\RegularExpression;
+use RecursiveFilterIterator;
+use RecursiveIterator;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+class NameFilterIterator extends RecursiveFilterIterator
+{
+    /**
+     * @var string
+     */
+    protected $filter;
+
+    /**
+     * @var int
+     */
+    protected $filterMin;
+
+    /**
+     * @var int
+     */
+    protected $filterMax;
+
+    /**
+     * @throws \Exception
+     */
+    public function __construct(RecursiveIterator $iterator, string $filter)
+    {
+        parent::__construct($iterator);
+
+        $this->setFilter($filter);
+    }
+
+    /**
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public function accept(): bool
+    {
+        $test = $this->getInnerIterator()->current();
+
+        if ($test instanceof TestSuite) {
+            return true;
+        }
+
+        $tmp = \PHPUnit\Util\Test::describe($test);
+
+        if ($test instanceof WarningTestCase) {
+            $name = $test->getMessage();
+        } else {
+            if ($tmp[0] !== '') {
+                $name = \implode('::', $tmp);
+            } else {
+                $name = $tmp[1];
+            }
+        }
+
+        $accepted = @\preg_match($this->filter, $name, $matches);
+
+        if ($accepted && isset($this->filterMax)) {
+            $set      = \end($matches);
+            $accepted = $set >= $this->filterMin && $set <= $this->filterMax;
+        }
+
+        return (bool) $accepted;
+    }
+
+    /**
+     * @throws \Exception
+     */
+    protected function setFilter(string $filter): void
+    {
+        if (RegularExpression::safeMatch($filter, '') === false) {
+            // Handles:
+            //  * testAssertEqualsSucceeds#4
+            //  * testAssertEqualsSucceeds#4-8
+            if (\preg_match('/^(.*?)#(\d+)(?:-(\d+))?$/', $filter, $matches)) {
+                if (isset($matches[3]) && $matches[2] < $matches[3]) {
+                    $filter = \sprintf(
+                        '%s.*with data set #(\d+)$',
+                        $matches[1]
+                    );
+
+                    $this->filterMin = $matches[2];
+                    $this->filterMax = $matches[3];
+                } else {
+                    $filter = \sprintf(
+                        '%s.*with data set #%s$',
+                        $matches[1],
+                        $matches[2]
+                    );
+                }
+            } // Handles:
+            //  * testDetermineJsonError@JSON_ERROR_NONE
+            //  * testDetermineJsonError@JSON.*
+            elseif (\preg_match('/^(.*?)@(.+)$/', $filter, $matches)) {
+                $filter = \sprintf(
+                    '%s.*with data set "%s"$',
+                    $matches[1],
+                    $matches[2]
+                );
+            }
+
+            // Escape delimiters in regular expression. Do NOT use preg_quote,
+            // to keep magic characters.
+            $filter = \sprintf('/%s/i', \str_replace(
+                '/',
+                '\\/',
+                $filter
+            ));
+        }
+
+        $this->filter = $filter;
+    }
+}

--- a/src/NonFinal/TestRunner.php
+++ b/src/NonFinal/TestRunner.php
@@ -1,0 +1,1318 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Codeception\PHPUnit\NonFinal;
+
+use PHPUnit\Framework\Error\Deprecated;
+use PHPUnit\Framework\Error\Notice;
+use PHPUnit\Framework\Error\Warning;
+use PHPUnit\Framework\Exception;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestResult;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Runner\AfterLastTestHook;
+use PHPUnit\Runner\BaseTestRunner;
+use PHPUnit\Runner\BeforeFirstTestHook;
+use PHPUnit\Runner\Filter\ExcludeGroupFilterIterator;
+use PHPUnit\Runner\Filter\Factory;
+use PHPUnit\Runner\Filter\IncludeGroupFilterIterator;
+use PHPUnit\Runner\Filter\NameFilterIterator;
+use PHPUnit\Runner\Hook;
+use PHPUnit\Runner\NullTestResultCache;
+use PHPUnit\Runner\ResultCacheExtension;
+use PHPUnit\Runner\StandardTestSuiteLoader;
+use PHPUnit\Runner\TestHook;
+use PHPUnit\Runner\TestListenerAdapter;
+use PHPUnit\Runner\TestResultCache;
+use PHPUnit\Runner\TestSuiteLoader;
+use PHPUnit\Runner\TestSuiteSorter;
+use PHPUnit\Runner\Version;
+use PHPUnit\TextUI\ResultPrinter;
+use PHPUnit\Util\Configuration;
+use PHPUnit\Util\Filesystem;
+use PHPUnit\Util\Log\JUnit;
+use PHPUnit\Util\Log\TeamCity;
+use PHPUnit\Util\Printer;
+use PHPUnit\Util\TestDox\CliTestDoxPrinter;
+use PHPUnit\Util\TestDox\HtmlResultPrinter;
+use PHPUnit\Util\TestDox\TextResultPrinter;
+use PHPUnit\Util\TestDox\XmlResultPrinter;
+use PHPUnit\Util\XdebugFilterScriptGenerator;
+use ReflectionClass;
+use SebastianBergmann\CodeCoverage\CodeCoverage;
+use SebastianBergmann\CodeCoverage\Exception as CodeCoverageException;
+use SebastianBergmann\CodeCoverage\Filter as CodeCoverageFilter;
+use SebastianBergmann\CodeCoverage\Report\Clover as CloverReport;
+use SebastianBergmann\CodeCoverage\Report\Crap4j as Crap4jReport;
+use SebastianBergmann\CodeCoverage\Report\Html\Facade as HtmlReport;
+use SebastianBergmann\CodeCoverage\Report\PHP as PhpReport;
+use SebastianBergmann\CodeCoverage\Report\Text as TextReport;
+use SebastianBergmann\CodeCoverage\Report\Xml\Facade as XmlReport;
+use SebastianBergmann\Comparator\Comparator;
+use SebastianBergmann\Environment\Runtime;
+use SebastianBergmann\Invoker\Invoker;
+
+/**
+ * @internal This class is not covered by the backward compatibility promise for PHPUnit
+ */
+class TestRunner extends BaseTestRunner
+{
+    public const SUCCESS_EXIT   = 0;
+
+    public const FAILURE_EXIT   = 1;
+
+    public const EXCEPTION_EXIT = 2;
+
+    /**
+     * @var bool
+     */
+    protected static $versionStringPrinted = false;
+
+    /**
+     * @var CodeCoverageFilter
+     */
+    protected $codeCoverageFilter;
+
+    /**
+     * @var TestSuiteLoader
+     */
+    protected $loader;
+
+    /**
+     * @var ResultPrinter
+     */
+    protected $printer;
+
+    /**
+     * @var Runtime
+     */
+    private $runtime;
+
+    /**
+     * @var bool
+     */
+    private $messagePrinted = false;
+
+    /**
+     * @var Hook[]
+     */
+    private $extensions = [];
+
+    /**
+     * @param ReflectionClass|Test $test
+     * @param bool                 $exit
+     *
+     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
+     * @throws Exception
+     * @throws \ReflectionException
+     */
+    public static function run($test, array $arguments = [], $exit = true): TestResult
+    {
+        if ($test instanceof ReflectionClass) {
+            $test = new TestSuite($test);
+        }
+
+        if ($test instanceof Test) {
+            $aTestRunner = new self;
+
+            return $aTestRunner->doRun(
+                $test,
+                $arguments,
+                $exit
+            );
+        }
+
+        throw new Exception('No test case or test suite found.');
+    }
+
+    public function __construct(TestSuiteLoader $loader = null, CodeCoverageFilter $filter = null)
+    {
+        if ($filter === null) {
+            $filter = new CodeCoverageFilter;
+        }
+
+        $this->codeCoverageFilter = $filter;
+        $this->loader             = $loader;
+        $this->runtime            = new Runtime;
+    }
+
+    /**
+     * @throws \PHPUnit\Runner\Exception
+     * @throws Exception
+     * @throws \InvalidArgumentException
+     * @throws \RuntimeException
+     * @throws \ReflectionException
+     */
+    public function doRun(Test $suite, array $arguments = [], bool $exit = true): TestResult
+    {
+        if (isset($arguments['configuration'])) {
+            $GLOBALS['__PHPUNIT_CONFIGURATION_FILE'] = $arguments['configuration'];
+        }
+
+        $this->handleConfiguration($arguments);
+
+        if (\is_int($arguments['columns']) && $arguments['columns'] < 16) {
+            $arguments['columns']   = 16;
+            $tooFewColumnsRequested = true;
+        }
+
+        if (isset($arguments['bootstrap'])) {
+            $GLOBALS['__PHPUNIT_BOOTSTRAP'] = $arguments['bootstrap'];
+        }
+
+        if ($suite instanceof TestCase || $suite instanceof TestSuite) {
+            if ($arguments['backupGlobals'] === true) {
+                $suite->setBackupGlobals(true);
+            }
+
+            if ($arguments['backupStaticAttributes'] === true) {
+                $suite->setBackupStaticAttributes(true);
+            }
+
+            if ($arguments['beStrictAboutChangesToGlobalState'] === true) {
+                $suite->setBeStrictAboutChangesToGlobalState(true);
+            }
+        }
+
+        if ($arguments['executionOrder'] === TestSuiteSorter::ORDER_RANDOMIZED) {
+            \mt_srand($arguments['randomOrderSeed']);
+        }
+
+        if ($arguments['cacheResult']) {
+            if (isset($arguments['cacheResultFile'])) {
+                $cache = new TestResultCache($arguments['cacheResultFile']);
+            } else {
+                $cache = new TestResultCache;
+            }
+
+            $this->addExtension(new ResultCacheExtension($cache));
+        }
+
+        if ($arguments['executionOrder'] !== TestSuiteSorter::ORDER_DEFAULT || $arguments['executionOrderDefects'] !== TestSuiteSorter::ORDER_DEFAULT || $arguments['resolveDependencies']) {
+            $cache = $cache ?? new NullTestResultCache;
+
+            $cache->load();
+
+            $sorter = new TestSuiteSorter($cache);
+
+            $sorter->reorderTestsInSuite($suite, $arguments['executionOrder'], $arguments['resolveDependencies'], $arguments['executionOrderDefects']);
+            $originalExecutionOrder = $sorter->getOriginalExecutionOrder();
+
+            unset($sorter);
+        }
+
+        if (\is_int($arguments['repeat']) && $arguments['repeat'] > 0) {
+            $_suite = new TestSuite;
+
+            /* @noinspection PhpUnusedLocalVariableInspection */
+            foreach (\range(1, $arguments['repeat']) as $step) {
+                $_suite->addTest($suite);
+            }
+
+            $suite = $_suite;
+
+            unset($_suite);
+        }
+
+        $result = $this->createTestResult();
+
+        $listener       = new TestListenerAdapter;
+        $listenerNeeded = false;
+
+        foreach ($this->extensions as $extension) {
+            if ($extension instanceof TestHook) {
+                $listener->add($extension);
+
+                $listenerNeeded = true;
+            }
+        }
+
+        if ($listenerNeeded) {
+            $result->addListener($listener);
+        }
+
+        unset($listener, $listenerNeeded);
+
+        if (!$arguments['convertErrorsToExceptions']) {
+            $result->convertErrorsToExceptions(false);
+        }
+
+        if (!$arguments['convertDeprecationsToExceptions']) {
+            Deprecated::$enabled = false;
+        }
+
+        if (!$arguments['convertNoticesToExceptions']) {
+            Notice::$enabled = false;
+        }
+
+        if (!$arguments['convertWarningsToExceptions']) {
+            Warning::$enabled = false;
+        }
+
+        if ($arguments['stopOnError']) {
+            $result->stopOnError(true);
+        }
+
+        if ($arguments['stopOnFailure']) {
+            $result->stopOnFailure(true);
+        }
+
+        if ($arguments['stopOnWarning']) {
+            $result->stopOnWarning(true);
+        }
+
+        if ($arguments['stopOnIncomplete']) {
+            $result->stopOnIncomplete(true);
+        }
+
+        if ($arguments['stopOnRisky']) {
+            $result->stopOnRisky(true);
+        }
+
+        if ($arguments['stopOnSkipped']) {
+            $result->stopOnSkipped(true);
+        }
+
+        if ($arguments['stopOnDefect']) {
+            $result->stopOnDefect(true);
+        }
+
+        if ($arguments['registerMockObjectsFromTestArgumentsRecursively']) {
+            $result->setRegisterMockObjectsFromTestArgumentsRecursively(true);
+        }
+
+        if ($this->printer === null) {
+            if (isset($arguments['printer']) &&
+                $arguments['printer'] instanceof Printer) {
+                $this->printer = $arguments['printer'];
+            } else {
+                $printerClass = ResultPrinter::class;
+
+                if (isset($arguments['printer']) && \is_string($arguments['printer']) && \class_exists($arguments['printer'], false)) {
+                    $class = new ReflectionClass($arguments['printer']);
+
+                    if ($class->isSubclassOf(ResultPrinter::class)) {
+                        $printerClass = $arguments['printer'];
+                    }
+                }
+
+                $this->printer = new $printerClass(
+                    (isset($arguments['stderr']) && $arguments['stderr'] === true) ? 'php://stderr' : null,
+                    $arguments['verbose'],
+                    $arguments['colors'],
+                    $arguments['debug'],
+                    $arguments['columns'],
+                    $arguments['reverseList']
+                );
+
+                if (isset($originalExecutionOrder) && ($this->printer instanceof CliTestDoxPrinter)) {
+                    /* @var CliTestDoxPrinter */
+                    $this->printer->setOriginalExecutionOrder($originalExecutionOrder);
+                }
+            }
+        }
+
+        $this->printer->write(
+            Version::getVersionString() . "\n"
+        );
+
+        self::$versionStringPrinted = true;
+
+        if ($arguments['verbose']) {
+            $this->writeMessage('Runtime', $this->runtime->getNameWithVersionAndCodeCoverageDriver());
+
+            if ($arguments['executionOrder'] === TestSuiteSorter::ORDER_RANDOMIZED) {
+                $this->writeMessage(
+                    'Random seed',
+                    (string) $arguments['randomOrderSeed']
+                );
+            }
+
+            if (isset($arguments['configuration'])) {
+                $this->writeMessage(
+                    'Configuration',
+                    $arguments['configuration']->getFilename()
+                );
+            }
+
+            foreach ($arguments['loadedExtensions'] as $extension) {
+                $this->writeMessage(
+                    'Extension',
+                    $extension
+                );
+            }
+
+            foreach ($arguments['notLoadedExtensions'] as $extension) {
+                $this->writeMessage(
+                    'Extension',
+                    $extension
+                );
+            }
+        }
+
+        if (isset($tooFewColumnsRequested)) {
+            $this->writeMessage('Error', 'Less than 16 columns requested, number of columns set to 16');
+        }
+
+        if ($this->runtime->discardsComments()) {
+            $this->writeMessage('Warning', 'opcache.save_comments=0 set; annotations will not work');
+        }
+
+        if (isset($arguments['configuration']) && $arguments['configuration']->hasValidationErrors()) {
+            $this->write(
+                "\n  Warning - The configuration file did not pass validation!\n  The following problems have been detected:\n"
+            );
+
+            foreach ($arguments['configuration']->getValidationErrors() as $line => $errors) {
+                $this->write(\sprintf("\n  Line %d:\n", $line));
+
+                foreach ($errors as $msg) {
+                    $this->write(\sprintf("  - %s\n", $msg));
+                }
+            }
+            $this->write("\n  Test results may not be as expected.\n\n");
+        }
+
+        foreach ($arguments['listeners'] as $listener) {
+            $result->addListener($listener);
+        }
+
+        $result->addListener($this->printer);
+
+        $codeCoverageReports = 0;
+
+        if (!isset($arguments['noLogging'])) {
+            if (isset($arguments['testdoxHTMLFile'])) {
+                $result->addListener(
+                    new HtmlResultPrinter(
+                        $arguments['testdoxHTMLFile'],
+                        $arguments['testdoxGroups'],
+                        $arguments['testdoxExcludeGroups']
+                    )
+                );
+            }
+
+            if (isset($arguments['testdoxTextFile'])) {
+                $result->addListener(
+                    new TextResultPrinter(
+                        $arguments['testdoxTextFile'],
+                        $arguments['testdoxGroups'],
+                        $arguments['testdoxExcludeGroups']
+                    )
+                );
+            }
+
+            if (isset($arguments['testdoxXMLFile'])) {
+                $result->addListener(
+                    new XmlResultPrinter(
+                        $arguments['testdoxXMLFile']
+                    )
+                );
+            }
+
+            if (isset($arguments['teamcityLogfile'])) {
+                $result->addListener(
+                    new TeamCity($arguments['teamcityLogfile'])
+                );
+            }
+
+            if (isset($arguments['junitLogfile'])) {
+                $result->addListener(
+                    new JUnit(
+                        $arguments['junitLogfile'],
+                        $arguments['reportUselessTests']
+                    )
+                );
+            }
+
+            if (isset($arguments['coverageClover'])) {
+                $codeCoverageReports++;
+            }
+
+            if (isset($arguments['coverageCrap4J'])) {
+                $codeCoverageReports++;
+            }
+
+            if (isset($arguments['coverageHtml'])) {
+                $codeCoverageReports++;
+            }
+
+            if (isset($arguments['coveragePHP'])) {
+                $codeCoverageReports++;
+            }
+
+            if (isset($arguments['coverageText'])) {
+                $codeCoverageReports++;
+            }
+
+            if (isset($arguments['coverageXml'])) {
+                $codeCoverageReports++;
+            }
+        }
+
+        if (isset($arguments['noCoverage'])) {
+            $codeCoverageReports = 0;
+        }
+
+        if ($codeCoverageReports > 0 && !$this->runtime->canCollectCodeCoverage()) {
+            $this->writeMessage('Error', 'No code coverage driver is available');
+
+            $codeCoverageReports = 0;
+        }
+
+        if ($codeCoverageReports > 0 || isset($arguments['xdebugFilterFile'])) {
+            $whitelistFromConfigurationFile = false;
+            $whitelistFromOption            = false;
+
+            if (isset($arguments['whitelist'])) {
+                $this->codeCoverageFilter->addDirectoryToWhitelist($arguments['whitelist']);
+
+                $whitelistFromOption = true;
+            }
+
+            if (isset($arguments['configuration'])) {
+                $filterConfiguration = $arguments['configuration']->getFilterConfiguration();
+
+                if (!empty($filterConfiguration['whitelist'])) {
+                    $whitelistFromConfigurationFile = true;
+                }
+
+                if (!empty($filterConfiguration['whitelist'])) {
+                    foreach ($filterConfiguration['whitelist']['include']['directory'] as $dir) {
+                        $this->codeCoverageFilter->addDirectoryToWhitelist(
+                            $dir['path'],
+                            $dir['suffix'],
+                            $dir['prefix']
+                        );
+                    }
+
+                    foreach ($filterConfiguration['whitelist']['include']['file'] as $file) {
+                        $this->codeCoverageFilter->addFileToWhitelist($file);
+                    }
+
+                    foreach ($filterConfiguration['whitelist']['exclude']['directory'] as $dir) {
+                        $this->codeCoverageFilter->removeDirectoryFromWhitelist(
+                            $dir['path'],
+                            $dir['suffix'],
+                            $dir['prefix']
+                        );
+                    }
+
+                    foreach ($filterConfiguration['whitelist']['exclude']['file'] as $file) {
+                        $this->codeCoverageFilter->removeFileFromWhitelist($file);
+                    }
+                }
+            }
+        }
+
+        if ($codeCoverageReports > 0) {
+            $codeCoverage = new CodeCoverage(
+                null,
+                $this->codeCoverageFilter
+            );
+
+            $codeCoverage->setUnintentionallyCoveredSubclassesWhitelist(
+                [Comparator::class]
+            );
+
+            $codeCoverage->setCheckForUnintentionallyCoveredCode(
+                $arguments['strictCoverage']
+            );
+
+            $codeCoverage->setCheckForMissingCoversAnnotation(
+                $arguments['strictCoverage']
+            );
+
+            if (isset($arguments['forceCoversAnnotation'])) {
+                $codeCoverage->setForceCoversAnnotation(
+                    $arguments['forceCoversAnnotation']
+                );
+            }
+
+            if (isset($arguments['ignoreDeprecatedCodeUnitsFromCodeCoverage'])) {
+                $codeCoverage->setIgnoreDeprecatedCode(
+                    $arguments['ignoreDeprecatedCodeUnitsFromCodeCoverage']
+                );
+            }
+
+            if (isset($arguments['disableCodeCoverageIgnore'])) {
+                $codeCoverage->setDisableIgnoredLines(true);
+            }
+
+            if (!empty($filterConfiguration['whitelist'])) {
+                $codeCoverage->setAddUncoveredFilesFromWhitelist(
+                    $filterConfiguration['whitelist']['addUncoveredFilesFromWhitelist']
+                );
+
+                $codeCoverage->setProcessUncoveredFilesFromWhitelist(
+                    $filterConfiguration['whitelist']['processUncoveredFilesFromWhitelist']
+                );
+            }
+
+            if (!$this->codeCoverageFilter->hasWhitelist()) {
+                if (!$whitelistFromConfigurationFile && !$whitelistFromOption) {
+                    $this->writeMessage('Error', 'No whitelist is configured, no code coverage will be generated.');
+                } else {
+                    $this->writeMessage('Error', 'Incorrect whitelist config, no code coverage will be generated.');
+                }
+
+                $codeCoverageReports = 0;
+
+                unset($codeCoverage);
+            }
+        }
+
+        if (isset($arguments['xdebugFilterFile'], $filterConfiguration)) {
+            $this->write("\n");
+
+            $script = (new XdebugFilterScriptGenerator)->generate($filterConfiguration['whitelist']);
+
+            if ($arguments['xdebugFilterFile'] !== 'php://stdout' && $arguments['xdebugFilterFile'] !== 'php://stderr' && !Filesystem::createDirectory(\dirname($arguments['xdebugFilterFile']))) {
+                $this->write(\sprintf('Cannot write Xdebug filter script to %s ' . \PHP_EOL, $arguments['xdebugFilterFile']));
+
+                exit(self::EXCEPTION_EXIT);
+            }
+
+            \file_put_contents($arguments['xdebugFilterFile'], $script);
+
+            $this->write(\sprintf('Wrote Xdebug filter script to %s ' . \PHP_EOL, $arguments['xdebugFilterFile']));
+
+            exit(self::SUCCESS_EXIT);
+        }
+
+        $this->printer->write("\n");
+
+        if (isset($codeCoverage)) {
+            $result->setCodeCoverage($codeCoverage);
+
+            if ($codeCoverageReports > 1 && isset($arguments['cacheTokens'])) {
+                $codeCoverage->setCacheTokens($arguments['cacheTokens']);
+            }
+        }
+
+        $result->beStrictAboutTestsThatDoNotTestAnything($arguments['reportUselessTests']);
+        $result->beStrictAboutOutputDuringTests($arguments['disallowTestOutput']);
+        $result->beStrictAboutTodoAnnotatedTests($arguments['disallowTodoAnnotatedTests']);
+        $result->beStrictAboutResourceUsageDuringSmallTests($arguments['beStrictAboutResourceUsageDuringSmallTests']);
+
+        if ($arguments['enforceTimeLimit'] === true) {
+            if (!\class_exists(Invoker::class)) {
+                $this->writeMessage('Error', 'Package phpunit/php-invoker is required for enforcing time limits');
+            }
+
+            if (!\extension_loaded('pcntl') || \strpos(\ini_get('disable_functions'), 'pcntl') !== false) {
+                $this->writeMessage('Error', 'PHP extension pcntl is required for enforcing time limits');
+            }
+        }
+        $result->enforceTimeLimit($arguments['enforceTimeLimit']);
+        $result->setDefaultTimeLimit($arguments['defaultTimeLimit']);
+        $result->setTimeoutForSmallTests($arguments['timeoutForSmallTests']);
+        $result->setTimeoutForMediumTests($arguments['timeoutForMediumTests']);
+        $result->setTimeoutForLargeTests($arguments['timeoutForLargeTests']);
+
+        if ($suite instanceof TestSuite) {
+            $this->processSuiteFilters($suite, $arguments);
+            $suite->setRunTestInSeparateProcess($arguments['processIsolation']);
+        }
+
+        foreach ($this->extensions as $extension) {
+            if ($extension instanceof BeforeFirstTestHook) {
+                $extension->executeBeforeFirstTest();
+            }
+        }
+
+        $suite->run($result);
+
+        foreach ($this->extensions as $extension) {
+            if ($extension instanceof AfterLastTestHook) {
+                $extension->executeAfterLastTest();
+            }
+        }
+
+        $result->flushListeners();
+
+        if ($this->printer instanceof ResultPrinter) {
+            $this->printer->printResult($result);
+        }
+
+        if (isset($codeCoverage)) {
+            if (isset($arguments['coverageClover'])) {
+                $this->printer->write(
+                    "\nGenerating code coverage report in Clover XML format ..."
+                );
+
+                try {
+                    $writer = new CloverReport;
+                    $writer->process($codeCoverage, $arguments['coverageClover']);
+
+                    $this->printer->write(" done\n");
+                    unset($writer);
+                } catch (CodeCoverageException $e) {
+                    $this->printer->write(
+                        " failed\n" . $e->getMessage() . "\n"
+                    );
+                }
+            }
+
+            if (isset($arguments['coverageCrap4J'])) {
+                $this->printer->write(
+                    "\nGenerating Crap4J report XML file ..."
+                );
+
+                try {
+                    $writer = new Crap4jReport($arguments['crap4jThreshold']);
+                    $writer->process($codeCoverage, $arguments['coverageCrap4J']);
+
+                    $this->printer->write(" done\n");
+                    unset($writer);
+                } catch (CodeCoverageException $e) {
+                    $this->printer->write(
+                        " failed\n" . $e->getMessage() . "\n"
+                    );
+                }
+            }
+
+            if (isset($arguments['coverageHtml'])) {
+                $this->printer->write(
+                    "\nGenerating code coverage report in HTML format ..."
+                );
+
+                try {
+                    $writer = new HtmlReport(
+                        $arguments['reportLowUpperBound'],
+                        $arguments['reportHighLowerBound'],
+                        \sprintf(
+                            ' and <a href="https://phpunit.de/">PHPUnit %s</a>',
+                            Version::id()
+                        )
+                    );
+
+                    $writer->process($codeCoverage, $arguments['coverageHtml']);
+
+                    $this->printer->write(" done\n");
+                    unset($writer);
+                } catch (CodeCoverageException $e) {
+                    $this->printer->write(
+                        " failed\n" . $e->getMessage() . "\n"
+                    );
+                }
+            }
+
+            if (isset($arguments['coveragePHP'])) {
+                $this->printer->write(
+                    "\nGenerating code coverage report in PHP format ..."
+                );
+
+                try {
+                    $writer = new PhpReport;
+                    $writer->process($codeCoverage, $arguments['coveragePHP']);
+
+                    $this->printer->write(" done\n");
+                    unset($writer);
+                } catch (CodeCoverageException $e) {
+                    $this->printer->write(
+                        " failed\n" . $e->getMessage() . "\n"
+                    );
+                }
+            }
+
+            if (isset($arguments['coverageText'])) {
+                if ($arguments['coverageText'] == 'php://stdout') {
+                    $outputStream = $this->printer;
+                    $colors       = $arguments['colors'] && $arguments['colors'] != ResultPrinter::COLOR_NEVER;
+                } else {
+                    $outputStream = new Printer($arguments['coverageText']);
+                    $colors       = false;
+                }
+
+                $processor = new TextReport(
+                    $arguments['reportLowUpperBound'],
+                    $arguments['reportHighLowerBound'],
+                    $arguments['coverageTextShowUncoveredFiles'],
+                    $arguments['coverageTextShowOnlySummary']
+                );
+
+                $outputStream->write(
+                    $processor->process($codeCoverage, $colors)
+                );
+            }
+
+            if (isset($arguments['coverageXml'])) {
+                $this->printer->write(
+                    "\nGenerating code coverage report in PHPUnit XML format ..."
+                );
+
+                try {
+                    $writer = new XmlReport(Version::id());
+                    $writer->process($codeCoverage, $arguments['coverageXml']);
+
+                    $this->printer->write(" done\n");
+                    unset($writer);
+                } catch (CodeCoverageException $e) {
+                    $this->printer->write(
+                        " failed\n" . $e->getMessage() . "\n"
+                    );
+                }
+            }
+        }
+
+        if ($exit) {
+            if ($result->wasSuccessful()) {
+                if ($arguments['failOnRisky'] && !$result->allHarmless()) {
+                    exit(self::FAILURE_EXIT);
+                }
+
+                if ($arguments['failOnWarning'] && $result->warningCount() > 0) {
+                    exit(self::FAILURE_EXIT);
+                }
+
+                exit(self::SUCCESS_EXIT);
+            }
+
+            if ($result->errorCount() > 0) {
+                exit(self::EXCEPTION_EXIT);
+            }
+
+            if ($result->failureCount() > 0) {
+                exit(self::FAILURE_EXIT);
+            }
+        }
+
+        return $result;
+    }
+
+    public function setPrinter(ResultPrinter $resultPrinter): void
+    {
+        $this->printer = $resultPrinter;
+    }
+
+    /**
+     * Returns the loader to be used.
+     */
+    public function getLoader(): TestSuiteLoader
+    {
+        if ($this->loader === null) {
+            $this->loader = new StandardTestSuiteLoader;
+        }
+
+        return $this->loader;
+    }
+
+    public function addExtension(TestHook $extension): void
+    {
+        $this->extensions[] = $extension;
+    }
+
+    protected function createTestResult(): TestResult
+    {
+        return new TestResult;
+    }
+
+    /**
+     * Override to define how to handle a failed loading of
+     * a test suite.
+     */
+    protected function runFailed(string $message): void
+    {
+        $this->write($message . \PHP_EOL);
+
+        exit(self::FAILURE_EXIT);
+    }
+
+    protected function write(string $buffer): void
+    {
+        if (\PHP_SAPI != 'cli' && \PHP_SAPI != 'phpdbg') {
+            $buffer = \htmlspecialchars($buffer);
+        }
+
+        if ($this->printer !== null) {
+            $this->printer->write($buffer);
+        } else {
+            print $buffer;
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function handleConfiguration(array &$arguments): void
+    {
+        if (isset($arguments['configuration']) &&
+            !$arguments['configuration'] instanceof Configuration) {
+            $arguments['configuration'] = Configuration::getInstance(
+                $arguments['configuration']
+            );
+        }
+
+        $arguments['debug']     = $arguments['debug'] ?? false;
+        $arguments['filter']    = $arguments['filter'] ?? false;
+        $arguments['listeners'] = $arguments['listeners'] ?? [];
+
+        if (isset($arguments['configuration'])) {
+            $arguments['configuration']->handlePHPConfiguration();
+
+            $phpunitConfiguration = $arguments['configuration']->getPHPUnitConfiguration();
+
+            if (isset($phpunitConfiguration['backupGlobals']) && !isset($arguments['backupGlobals'])) {
+                $arguments['backupGlobals'] = $phpunitConfiguration['backupGlobals'];
+            }
+
+            if (isset($phpunitConfiguration['backupStaticAttributes']) && !isset($arguments['backupStaticAttributes'])) {
+                $arguments['backupStaticAttributes'] = $phpunitConfiguration['backupStaticAttributes'];
+            }
+
+            if (isset($phpunitConfiguration['beStrictAboutChangesToGlobalState']) && !isset($arguments['beStrictAboutChangesToGlobalState'])) {
+                $arguments['beStrictAboutChangesToGlobalState'] = $phpunitConfiguration['beStrictAboutChangesToGlobalState'];
+            }
+
+            if (isset($phpunitConfiguration['bootstrap']) && !isset($arguments['bootstrap'])) {
+                $arguments['bootstrap'] = $phpunitConfiguration['bootstrap'];
+            }
+
+            if (isset($phpunitConfiguration['cacheResult']) && !isset($arguments['cacheResult'])) {
+                $arguments['cacheResult'] = $phpunitConfiguration['cacheResult'];
+            }
+
+            if (isset($phpunitConfiguration['cacheResultFile']) && !isset($arguments['cacheResultFile'])) {
+                $arguments['cacheResultFile'] = $phpunitConfiguration['cacheResultFile'];
+            }
+
+            if (isset($phpunitConfiguration['cacheTokens']) && !isset($arguments['cacheTokens'])) {
+                $arguments['cacheTokens'] = $phpunitConfiguration['cacheTokens'];
+            }
+
+            if (isset($phpunitConfiguration['cacheTokens']) && !isset($arguments['cacheTokens'])) {
+                $arguments['cacheTokens'] = $phpunitConfiguration['cacheTokens'];
+            }
+
+            if (isset($phpunitConfiguration['colors']) && !isset($arguments['colors'])) {
+                $arguments['colors'] = $phpunitConfiguration['colors'];
+            }
+
+            if (isset($phpunitConfiguration['convertDeprecationsToExceptions']) && !isset($arguments['convertDeprecationsToExceptions'])) {
+                $arguments['convertDeprecationsToExceptions'] = $phpunitConfiguration['convertDeprecationsToExceptions'];
+            }
+
+            if (isset($phpunitConfiguration['convertErrorsToExceptions']) && !isset($arguments['convertErrorsToExceptions'])) {
+                $arguments['convertErrorsToExceptions'] = $phpunitConfiguration['convertErrorsToExceptions'];
+            }
+
+            if (isset($phpunitConfiguration['convertNoticesToExceptions']) && !isset($arguments['convertNoticesToExceptions'])) {
+                $arguments['convertNoticesToExceptions'] = $phpunitConfiguration['convertNoticesToExceptions'];
+            }
+
+            if (isset($phpunitConfiguration['convertWarningsToExceptions']) && !isset($arguments['convertWarningsToExceptions'])) {
+                $arguments['convertWarningsToExceptions'] = $phpunitConfiguration['convertWarningsToExceptions'];
+            }
+
+            if (isset($phpunitConfiguration['processIsolation']) && !isset($arguments['processIsolation'])) {
+                $arguments['processIsolation'] = $phpunitConfiguration['processIsolation'];
+            }
+
+            if (isset($phpunitConfiguration['stopOnDefect']) && !isset($arguments['stopOnDefect'])) {
+                $arguments['stopOnDefect'] = $phpunitConfiguration['stopOnDefect'];
+            }
+
+            if (isset($phpunitConfiguration['stopOnError']) && !isset($arguments['stopOnError'])) {
+                $arguments['stopOnError'] = $phpunitConfiguration['stopOnError'];
+            }
+
+            if (isset($phpunitConfiguration['stopOnFailure']) && !isset($arguments['stopOnFailure'])) {
+                $arguments['stopOnFailure'] = $phpunitConfiguration['stopOnFailure'];
+            }
+
+            if (isset($phpunitConfiguration['stopOnWarning']) && !isset($arguments['stopOnWarning'])) {
+                $arguments['stopOnWarning'] = $phpunitConfiguration['stopOnWarning'];
+            }
+
+            if (isset($phpunitConfiguration['stopOnIncomplete']) && !isset($arguments['stopOnIncomplete'])) {
+                $arguments['stopOnIncomplete'] = $phpunitConfiguration['stopOnIncomplete'];
+            }
+
+            if (isset($phpunitConfiguration['stopOnRisky']) && !isset($arguments['stopOnRisky'])) {
+                $arguments['stopOnRisky'] = $phpunitConfiguration['stopOnRisky'];
+            }
+
+            if (isset($phpunitConfiguration['stopOnSkipped']) && !isset($arguments['stopOnSkipped'])) {
+                $arguments['stopOnSkipped'] = $phpunitConfiguration['stopOnSkipped'];
+            }
+
+            if (isset($phpunitConfiguration['failOnWarning']) && !isset($arguments['failOnWarning'])) {
+                $arguments['failOnWarning'] = $phpunitConfiguration['failOnWarning'];
+            }
+
+            if (isset($phpunitConfiguration['failOnRisky']) && !isset($arguments['failOnRisky'])) {
+                $arguments['failOnRisky'] = $phpunitConfiguration['failOnRisky'];
+            }
+
+            if (isset($phpunitConfiguration['timeoutForSmallTests']) && !isset($arguments['timeoutForSmallTests'])) {
+                $arguments['timeoutForSmallTests'] = $phpunitConfiguration['timeoutForSmallTests'];
+            }
+
+            if (isset($phpunitConfiguration['timeoutForMediumTests']) && !isset($arguments['timeoutForMediumTests'])) {
+                $arguments['timeoutForMediumTests'] = $phpunitConfiguration['timeoutForMediumTests'];
+            }
+
+            if (isset($phpunitConfiguration['timeoutForLargeTests']) && !isset($arguments['timeoutForLargeTests'])) {
+                $arguments['timeoutForLargeTests'] = $phpunitConfiguration['timeoutForLargeTests'];
+            }
+
+            if (isset($phpunitConfiguration['reportUselessTests']) && !isset($arguments['reportUselessTests'])) {
+                $arguments['reportUselessTests'] = $phpunitConfiguration['reportUselessTests'];
+            }
+
+            if (isset($phpunitConfiguration['strictCoverage']) && !isset($arguments['strictCoverage'])) {
+                $arguments['strictCoverage'] = $phpunitConfiguration['strictCoverage'];
+            }
+
+            if (isset($phpunitConfiguration['ignoreDeprecatedCodeUnitsFromCodeCoverage']) && !isset($arguments['ignoreDeprecatedCodeUnitsFromCodeCoverage'])) {
+                $arguments['ignoreDeprecatedCodeUnitsFromCodeCoverage'] = $phpunitConfiguration['ignoreDeprecatedCodeUnitsFromCodeCoverage'];
+            }
+
+            if (isset($phpunitConfiguration['disallowTestOutput']) && !isset($arguments['disallowTestOutput'])) {
+                $arguments['disallowTestOutput'] = $phpunitConfiguration['disallowTestOutput'];
+            }
+
+            if (isset($phpunitConfiguration['defaultTimeLimit']) && !isset($arguments['defaultTimeLimit'])) {
+                $arguments['defaultTimeLimit'] = $phpunitConfiguration['defaultTimeLimit'];
+            }
+
+            if (isset($phpunitConfiguration['enforceTimeLimit']) && !isset($arguments['enforceTimeLimit'])) {
+                $arguments['enforceTimeLimit'] = $phpunitConfiguration['enforceTimeLimit'];
+            }
+
+            if (isset($phpunitConfiguration['disallowTodoAnnotatedTests']) && !isset($arguments['disallowTodoAnnotatedTests'])) {
+                $arguments['disallowTodoAnnotatedTests'] = $phpunitConfiguration['disallowTodoAnnotatedTests'];
+            }
+
+            if (isset($phpunitConfiguration['beStrictAboutResourceUsageDuringSmallTests']) && !isset($arguments['beStrictAboutResourceUsageDuringSmallTests'])) {
+                $arguments['beStrictAboutResourceUsageDuringSmallTests'] = $phpunitConfiguration['beStrictAboutResourceUsageDuringSmallTests'];
+            }
+
+            if (isset($phpunitConfiguration['verbose']) && !isset($arguments['verbose'])) {
+                $arguments['verbose'] = $phpunitConfiguration['verbose'];
+            }
+
+            if (isset($phpunitConfiguration['reverseDefectList']) && !isset($arguments['reverseList'])) {
+                $arguments['reverseList'] = $phpunitConfiguration['reverseDefectList'];
+            }
+
+            if (isset($phpunitConfiguration['forceCoversAnnotation']) && !isset($arguments['forceCoversAnnotation'])) {
+                $arguments['forceCoversAnnotation'] = $phpunitConfiguration['forceCoversAnnotation'];
+            }
+
+            if (isset($phpunitConfiguration['disableCodeCoverageIgnore']) && !isset($arguments['disableCodeCoverageIgnore'])) {
+                $arguments['disableCodeCoverageIgnore'] = $phpunitConfiguration['disableCodeCoverageIgnore'];
+            }
+
+            if (isset($phpunitConfiguration['registerMockObjectsFromTestArgumentsRecursively']) && !isset($arguments['registerMockObjectsFromTestArgumentsRecursively'])) {
+                $arguments['registerMockObjectsFromTestArgumentsRecursively'] = $phpunitConfiguration['registerMockObjectsFromTestArgumentsRecursively'];
+            }
+
+            if (isset($phpunitConfiguration['executionOrder']) && !isset($arguments['executionOrder'])) {
+                $arguments['executionOrder'] = $phpunitConfiguration['executionOrder'];
+            }
+
+            if (isset($phpunitConfiguration['executionOrderDefects']) && !isset($arguments['executionOrderDefects'])) {
+                $arguments['executionOrderDefects'] = $phpunitConfiguration['executionOrderDefects'];
+            }
+
+            if (isset($phpunitConfiguration['resolveDependencies']) && !isset($arguments['resolveDependencies'])) {
+                $arguments['resolveDependencies'] = $phpunitConfiguration['resolveDependencies'];
+            }
+
+            $groupCliArgs = [];
+
+            if (!empty($arguments['groups'])) {
+                $groupCliArgs = $arguments['groups'];
+            }
+
+            $groupConfiguration = $arguments['configuration']->getGroupConfiguration();
+
+            if (!empty($groupConfiguration['include']) && !isset($arguments['groups'])) {
+                $arguments['groups'] = $groupConfiguration['include'];
+            }
+
+            if (!empty($groupConfiguration['exclude']) && !isset($arguments['excludeGroups'])) {
+                $arguments['excludeGroups'] = \array_diff($groupConfiguration['exclude'], $groupCliArgs);
+            }
+
+            foreach ($arguments['configuration']->getExtensionConfiguration() as $extension) {
+                if (!\class_exists($extension['class'], false) && $extension['file'] !== '') {
+                    require_once $extension['file'];
+                }
+
+                if (!\class_exists($extension['class'])) {
+                    throw new Exception(
+                        \sprintf(
+                            'Class "%s" does not exist',
+                            $extension['class']
+                        )
+                    );
+                }
+
+                $extensionClass = new ReflectionClass($extension['class']);
+
+                if (!$extensionClass->implementsInterface(Hook::class)) {
+                    throw new Exception(
+                        \sprintf(
+                            'Class "%s" does not implement a PHPUnit\Runner\Hook interface',
+                            $extension['class']
+                        )
+                    );
+                }
+
+                if (\count($extension['arguments']) == 0) {
+                    $extensionObject = $extensionClass->newInstance();
+                } else {
+                    $extensionObject = $extensionClass->newInstanceArgs(
+                        $extension['arguments']
+                    );
+                }
+
+                \assert($extensionObject instanceof TestHook);
+
+                $this->addExtension($extensionObject);
+            }
+
+            foreach ($arguments['configuration']->getListenerConfiguration() as $listener) {
+                if (!\class_exists($listener['class'], false) &&
+                    $listener['file'] !== '') {
+                    require_once $listener['file'];
+                }
+
+                if (!\class_exists($listener['class'])) {
+                    throw new Exception(
+                        \sprintf(
+                            'Class "%s" does not exist',
+                            $listener['class']
+                        )
+                    );
+                }
+
+                $listenerClass = new ReflectionClass($listener['class']);
+
+                if (!$listenerClass->implementsInterface(TestListener::class)) {
+                    throw new Exception(
+                        \sprintf(
+                            'Class "%s" does not implement the PHPUnit\Framework\TestListener interface',
+                            $listener['class']
+                        )
+                    );
+                }
+
+                if (\count($listener['arguments']) == 0) {
+                    $listener = new $listener['class'];
+                } else {
+                    $listener = $listenerClass->newInstanceArgs(
+                        $listener['arguments']
+                    );
+                }
+
+                $arguments['listeners'][] = $listener;
+            }
+
+            $loggingConfiguration = $arguments['configuration']->getLoggingConfiguration();
+
+            if (isset($loggingConfiguration['coverage-clover']) && !isset($arguments['coverageClover'])) {
+                $arguments['coverageClover'] = $loggingConfiguration['coverage-clover'];
+            }
+
+            if (isset($loggingConfiguration['coverage-crap4j']) && !isset($arguments['coverageCrap4J'])) {
+                $arguments['coverageCrap4J'] = $loggingConfiguration['coverage-crap4j'];
+
+                if (isset($loggingConfiguration['crap4jThreshold']) && !isset($arguments['crap4jThreshold'])) {
+                    $arguments['crap4jThreshold'] = $loggingConfiguration['crap4jThreshold'];
+                }
+            }
+
+            if (isset($loggingConfiguration['coverage-html']) && !isset($arguments['coverageHtml'])) {
+                if (isset($loggingConfiguration['lowUpperBound']) && !isset($arguments['reportLowUpperBound'])) {
+                    $arguments['reportLowUpperBound'] = $loggingConfiguration['lowUpperBound'];
+                }
+
+                if (isset($loggingConfiguration['highLowerBound']) && !isset($arguments['reportHighLowerBound'])) {
+                    $arguments['reportHighLowerBound'] = $loggingConfiguration['highLowerBound'];
+                }
+
+                $arguments['coverageHtml'] = $loggingConfiguration['coverage-html'];
+            }
+
+            if (isset($loggingConfiguration['coverage-php']) && !isset($arguments['coveragePHP'])) {
+                $arguments['coveragePHP'] = $loggingConfiguration['coverage-php'];
+            }
+
+            if (isset($loggingConfiguration['coverage-text']) && !isset($arguments['coverageText'])) {
+                $arguments['coverageText'] = $loggingConfiguration['coverage-text'];
+
+                if (isset($loggingConfiguration['coverageTextShowUncoveredFiles'])) {
+                    $arguments['coverageTextShowUncoveredFiles'] = $loggingConfiguration['coverageTextShowUncoveredFiles'];
+                } else {
+                    $arguments['coverageTextShowUncoveredFiles'] = false;
+                }
+
+                if (isset($loggingConfiguration['coverageTextShowOnlySummary'])) {
+                    $arguments['coverageTextShowOnlySummary'] = $loggingConfiguration['coverageTextShowOnlySummary'];
+                } else {
+                    $arguments['coverageTextShowOnlySummary'] = false;
+                }
+            }
+
+            if (isset($loggingConfiguration['coverage-xml']) && !isset($arguments['coverageXml'])) {
+                $arguments['coverageXml'] = $loggingConfiguration['coverage-xml'];
+            }
+
+            if (isset($loggingConfiguration['plain'])) {
+                $arguments['listeners'][] = new ResultPrinter(
+                    $loggingConfiguration['plain'],
+                    true
+                );
+            }
+
+            if (isset($loggingConfiguration['teamcity']) && !isset($arguments['teamcityLogfile'])) {
+                $arguments['teamcityLogfile'] = $loggingConfiguration['teamcity'];
+            }
+
+            if (isset($loggingConfiguration['junit']) && !isset($arguments['junitLogfile'])) {
+                $arguments['junitLogfile'] = $loggingConfiguration['junit'];
+            }
+
+            if (isset($loggingConfiguration['testdox-html']) && !isset($arguments['testdoxHTMLFile'])) {
+                $arguments['testdoxHTMLFile'] = $loggingConfiguration['testdox-html'];
+            }
+
+            if (isset($loggingConfiguration['testdox-text']) && !isset($arguments['testdoxTextFile'])) {
+                $arguments['testdoxTextFile'] = $loggingConfiguration['testdox-text'];
+            }
+
+            if (isset($loggingConfiguration['testdox-xml']) && !isset($arguments['testdoxXMLFile'])) {
+                $arguments['testdoxXMLFile'] = $loggingConfiguration['testdox-xml'];
+            }
+
+            $testdoxGroupConfiguration = $arguments['configuration']->getTestdoxGroupConfiguration();
+
+            if (isset($testdoxGroupConfiguration['include']) &&
+                !isset($arguments['testdoxGroups'])) {
+                $arguments['testdoxGroups'] = $testdoxGroupConfiguration['include'];
+            }
+
+            if (isset($testdoxGroupConfiguration['exclude']) &&
+                !isset($arguments['testdoxExcludeGroups'])) {
+                $arguments['testdoxExcludeGroups'] = $testdoxGroupConfiguration['exclude'];
+            }
+        }
+
+        $arguments['addUncoveredFilesFromWhitelist']                  = $arguments['addUncoveredFilesFromWhitelist'] ?? true;
+        $arguments['backupGlobals']                                   = $arguments['backupGlobals'] ?? null;
+        $arguments['backupStaticAttributes']                          = $arguments['backupStaticAttributes'] ?? null;
+        $arguments['beStrictAboutChangesToGlobalState']               = $arguments['beStrictAboutChangesToGlobalState'] ?? null;
+        $arguments['beStrictAboutResourceUsageDuringSmallTests']      = $arguments['beStrictAboutResourceUsageDuringSmallTests'] ?? false;
+        $arguments['cacheResult']                                     = $arguments['cacheResult'] ?? true;
+        $arguments['cacheTokens']                                     = $arguments['cacheTokens'] ?? false;
+        $arguments['colors']                                          = $arguments['colors'] ?? ResultPrinter::COLOR_DEFAULT;
+        $arguments['columns']                                         = $arguments['columns'] ?? 80;
+        $arguments['convertDeprecationsToExceptions']                 = $arguments['convertDeprecationsToExceptions'] ?? true;
+        $arguments['convertErrorsToExceptions']                       = $arguments['convertErrorsToExceptions'] ?? true;
+        $arguments['convertNoticesToExceptions']                      = $arguments['convertNoticesToExceptions'] ?? true;
+        $arguments['convertWarningsToExceptions']                     = $arguments['convertWarningsToExceptions'] ?? true;
+        $arguments['crap4jThreshold']                                 = $arguments['crap4jThreshold'] ?? 30;
+        $arguments['disallowTestOutput']                              = $arguments['disallowTestOutput'] ?? false;
+        $arguments['disallowTodoAnnotatedTests']                      = $arguments['disallowTodoAnnotatedTests'] ?? false;
+        $arguments['defaultTimeLimit']                                = $arguments['defaultTimeLimit'] ?? 0;
+        $arguments['enforceTimeLimit']                                = $arguments['enforceTimeLimit'] ?? false;
+        $arguments['excludeGroups']                                   = $arguments['excludeGroups'] ?? [];
+        $arguments['failOnRisky']                                     = $arguments['failOnRisky'] ?? false;
+        $arguments['failOnWarning']                                   = $arguments['failOnWarning'] ?? false;
+        $arguments['executionOrderDefects']                           = $arguments['executionOrderDefects'] ?? TestSuiteSorter::ORDER_DEFAULT;
+        $arguments['groups']                                          = $arguments['groups'] ?? [];
+        $arguments['processIsolation']                                = $arguments['processIsolation'] ?? false;
+        $arguments['processUncoveredFilesFromWhitelist']              = $arguments['processUncoveredFilesFromWhitelist'] ?? false;
+        $arguments['randomOrderSeed']                                 = $arguments['randomOrderSeed'] ?? \time();
+        $arguments['registerMockObjectsFromTestArgumentsRecursively'] = $arguments['registerMockObjectsFromTestArgumentsRecursively'] ?? false;
+        $arguments['repeat']                                          = $arguments['repeat'] ?? false;
+        $arguments['reportHighLowerBound']                            = $arguments['reportHighLowerBound'] ?? 90;
+        $arguments['reportLowUpperBound']                             = $arguments['reportLowUpperBound'] ?? 50;
+        $arguments['reportUselessTests']                              = $arguments['reportUselessTests'] ?? true;
+        $arguments['reverseList']                                     = $arguments['reverseList'] ?? false;
+        $arguments['executionOrder']                                  = $arguments['executionOrder'] ?? TestSuiteSorter::ORDER_DEFAULT;
+        $arguments['resolveDependencies']                             = $arguments['resolveDependencies'] ?? true;
+        $arguments['stopOnError']                                     = $arguments['stopOnError'] ?? false;
+        $arguments['stopOnFailure']                                   = $arguments['stopOnFailure'] ?? false;
+        $arguments['stopOnIncomplete']                                = $arguments['stopOnIncomplete'] ?? false;
+        $arguments['stopOnRisky']                                     = $arguments['stopOnRisky'] ?? false;
+        $arguments['stopOnSkipped']                                   = $arguments['stopOnSkipped'] ?? false;
+        $arguments['stopOnWarning']                                   = $arguments['stopOnWarning'] ?? false;
+        $arguments['stopOnDefect']                                    = $arguments['stopOnDefect'] ?? false;
+        $arguments['strictCoverage']                                  = $arguments['strictCoverage'] ?? false;
+        $arguments['testdoxExcludeGroups']                            = $arguments['testdoxExcludeGroups'] ?? [];
+        $arguments['testdoxGroups']                                   = $arguments['testdoxGroups'] ?? [];
+        $arguments['timeoutForLargeTests']                            = $arguments['timeoutForLargeTests'] ?? 60;
+        $arguments['timeoutForMediumTests']                           = $arguments['timeoutForMediumTests'] ?? 10;
+        $arguments['timeoutForSmallTests']                            = $arguments['timeoutForSmallTests'] ?? 1;
+        $arguments['verbose']                                         = $arguments['verbose'] ?? false;
+    }
+
+    /**
+     * @throws \ReflectionException
+     * @throws \InvalidArgumentException
+     */
+    private function processSuiteFilters(TestSuite $suite, array $arguments): void
+    {
+        if (!$arguments['filter'] &&
+            empty($arguments['groups']) &&
+            empty($arguments['excludeGroups'])) {
+            return;
+        }
+
+        $filterFactory = new Factory;
+
+        if (!empty($arguments['excludeGroups'])) {
+            $filterFactory->addFilter(
+                new ReflectionClass(ExcludeGroupFilterIterator::class),
+                $arguments['excludeGroups']
+            );
+        }
+
+        if (!empty($arguments['groups'])) {
+            $filterFactory->addFilter(
+                new ReflectionClass(IncludeGroupFilterIterator::class),
+                $arguments['groups']
+            );
+        }
+
+        if ($arguments['filter']) {
+            $filterFactory->addFilter(
+                new ReflectionClass(NameFilterIterator::class),
+                $arguments['filter']
+            );
+        }
+
+        $suite->injectFilter($filterFactory);
+    }
+
+    private function writeMessage(string $type, string $message): void
+    {
+        if (!$this->messagePrinted) {
+            $this->write("\n");
+        }
+
+        $this->write(
+            \sprintf(
+                "%-15s%s\n",
+                $type . ':',
+                $message
+            )
+        );
+
+        $this->messagePrinted = true;
+    }
+}

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -3,9 +3,8 @@ namespace Codeception\PHPUnit;
 
 use Codeception\Configuration;
 use Codeception\Exception\ConfigurationException;
-use PHPUnit\Framework\TestSuite;
 
-class Runner extends \PHPUnit\TextUI\TestRunner
+class Runner extends NonFinal\TestRunner
 {
     public static $persistentListeners = [];
 

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Codeception\PHPUnit;
+
+
+abstract class TestCase extends \PHPUnit\Framework\TestCase
+{
+
+    protected function setUp(): void
+    {
+        if (method_exists($this, '_setUp')) {
+            $this->_setUp();
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (method_exists($this, '_tearDown')) {
+            $this->_tearDown();
+        }
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        if (method_exists(get_called_class(), '_setUpBeforeClass')) {
+            static::_setUpBeforeClass();
+        }
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (method_exists(get_called_class(), '_tearDownAfterClass')) {
+            static::_tearDownAfterClass();
+        }
+    }
+}


### PR DESCRIPTION
I solved signature change problem with `setUp`, `tearDown` and `setUpBeforeClass`,
but I have no idea how to solve a problem of final class declarations.

`PHP Fatal error:  Class Codeception\PHPUnit\Runner may not inherit from final class (PHPUnit\TextUI\TestRunner)`
Other final class that we used to extend are `\PHPUnit\Runner\Filter\NameFilterIterator` and `\PHPUnit\Util\Log\JUnit`.
