### PR TITLE
#4413 HTML Report wrong steps/substeps nesting

### DIFF
--- a/src/ResultPrinter/HTML.php
+++ b/src/ResultPrinter/HTML.php
@@ -96,21 +96,20 @@ class HTML extends CodeceptionResultPrinter
         }
 
         $stepsBuffer = '';
-        $subStepsBuffer = '';
         $subStepsRendered = [];
 
         foreach ($steps as $step) {
             if ($step->getMetaStep()) {
-                $subStepsRendered[$step->getMetaStep()->getAction()][] = $this->renderStep($step);
+                $key = $step->getMetaStep()->getLine() . $step->getMetaStep()->getAction();
+                $subStepsRendered[$key][] = $this->renderStep($step);
             }
         }
-
         foreach ($steps as $step) {
             if ($step->getMetaStep()) {
-                if (! empty($subStepsRendered[$step->getMetaStep()->getAction()])) {
-                    $subStepsBuffer = implode('', $subStepsRendered[$step->getMetaStep()->getAction()]);
-                    unset($subStepsRendered[$step->getMetaStep()->getAction()]);
-
+                $key = $step->getMetaStep()->getLine() . $step->getMetaStep()->getAction();
+                if (! empty($subStepsRendered[$key])) {
+                    $subStepsBuffer = implode('', $subStepsRendered[$key]);
+                    unset($subStepsRendered[$key]);
                     $stepsBuffer .= $this->renderSubsteps($step->getMetaStep(), $subStepsBuffer);
                 }
             } else {


### PR DESCRIPTION
Previously using/calling the same meta step more than once (e.g. calling the same PageObject method twice), led to rendering all the steps from the meta step nested below the first meta step execution/node again and again, instead of several meta step executions/nodes (with each having just all steps from the meta step once).