### PR TITLE
Symfony 5 support for PHPUnit 7 branch

### DIFF
--- a/src/DispatcherWrapper.php
+++ b/src/DispatcherWrapper.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Codeception\PHPUnit;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+trait DispatcherWrapper
+{
+    /**
+     * Compatibility wrapper for dispatcher change between Symfony 4 and 5
+     * @param EventDispatcher $dispatcher
+     * @param string $eventType
+     * @param Event $eventObject
+     */
+    protected function dispatch(EventDispatcher $dispatcher, $eventType, Event $eventObject)
+    {
+        if (class_exists('Symfony\Contracts\EventDispatcher\Event')) {
+            //Symfony 5
+            $dispatcher->dispatch($eventObject, $eventType);
+        } else {
+            //Symfony 2,3 or 4
+            $dispatcher->dispatch($eventType, $eventObject);
+        }
+
+    }
+}

--- a/src/DispatcherWrapper.php
+++ b/src/DispatcherWrapper.php
@@ -4,6 +4,7 @@ namespace Codeception\PHPUnit;
 
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcherInterface;
 
 trait DispatcherWrapper
 {
@@ -15,7 +16,8 @@ trait DispatcherWrapper
      */
     protected function dispatch(EventDispatcher $dispatcher, $eventType, Event $eventObject)
     {
-        if (class_exists('Symfony\Contracts\EventDispatcher\Event')) {
+        //TraceableEventDispatcherInterface was introduced in symfony/event-dispatcher 2.5 and removed in 5.0
+        if (!interface_exists(TraceableEventDispatcherInterface::class)) {
             //Symfony 5
             $dispatcher->dispatch($eventObject, $eventType);
         } else {

--- a/src/Listener.php
+++ b/src/Listener.php
@@ -1,17 +1,18 @@
 <?php
 namespace Codeception\PHPUnit;
 
+use Codeception\PHPUnit\DispatcherWrapper;
 use Codeception\Event\FailEvent;
 use Codeception\Event\SuiteEvent;
 use Codeception\Event\TestEvent;
 use Codeception\Events;
 use Codeception\TestInterface;
-use Exception;
-use PHPUnit\Framework\Test;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class Listener implements \PHPUnit\Framework\TestListener
 {
+    use DispatcherWrapper;
+
     /**
      * @var \Symfony\Component\EventDispatcher\EventDispatcher
      */
@@ -79,17 +80,17 @@ class Listener implements \PHPUnit\Framework\TestListener
 
     public function startTestSuite(\PHPUnit\Framework\TestSuite $suite) : void
     {
-        $this->dispatcher->dispatch('suite.start', new SuiteEvent($suite));
+        $this->dispatch($this->dispatcher, 'suite.start', new SuiteEvent($suite));
     }
 
     public function endTestSuite(\PHPUnit\Framework\TestSuite $suite) : void
     {
-        $this->dispatcher->dispatch('suite.end', new SuiteEvent($suite));
+        $this->dispatch($this->dispatcher, 'suite.end', new SuiteEvent($suite));
     }
 
     public function startTest(\PHPUnit\Framework\Test $test) : void
     {
-        $this->dispatcher->dispatch(Events::TEST_START, new TestEvent($test));
+        $this->dispatch($this->dispatcher, Events::TEST_START, new TestEvent($test));
         if (!$test instanceof TestInterface) {
             return;
         }
@@ -119,7 +120,7 @@ class Listener implements \PHPUnit\Framework\TestListener
             $this->fire(Events::TEST_AFTER, new TestEvent($test, $time));
         }
 
-        $this->dispatcher->dispatch(Events::TEST_END, new TestEvent($test, $time));
+        $this->dispatch($this->dispatcher, Events::TEST_END, new TestEvent($test, $time));
     }
 
     protected function fire($event, TestEvent $eventType)
@@ -127,9 +128,9 @@ class Listener implements \PHPUnit\Framework\TestListener
         $test = $eventType->getTest();
         if ($test instanceof TestInterface) {
             foreach ($test->getMetadata()->getGroups() as $group) {
-                $this->dispatcher->dispatch($event . '.' . $group, $eventType);
+                $this->dispatch($this->dispatcher, $event . '.' . $group, $eventType);
             }
         }
-        $this->dispatcher->dispatch($event, $eventType);
+        $this->dispatch($this->dispatcher, $event, $eventType);
     }
 }

--- a/src/ResultPrinter/UI.php
+++ b/src/ResultPrinter/UI.php
@@ -3,12 +3,15 @@ namespace Codeception\PHPUnit\ResultPrinter;
 
 use Codeception\Event\FailEvent;
 use Codeception\Events;
+use Codeception\PHPUnit\DispatcherWrapper;
 use Codeception\Test\Unit;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class UI extends \PHPUnit\TextUI\ResultPrinter
 {
+    use DispatcherWrapper;
+
     /**
      * @var EventDispatcher
      */
@@ -23,7 +26,8 @@ class UI extends \PHPUnit\TextUI\ResultPrinter
     protected function printDefect(\PHPUnit\Framework\TestFailure $defect, int $count): void
     {
         $this->write("\n---------\n");
-        $this->dispatcher->dispatch(
+        $this->dispatch(
+            $this->dispatcher,
             Events::TEST_FAIL_PRINT,
             new FailEvent($defect->failedTest(), null, $defect->thrownException(), $count)
         );


### PR DESCRIPTION
I think that adding Symfony 5 support for PHPUnit 7 is the easiest way to get module-yii2 builds passing.