### PR TITLE
Runner: ignore warnings caused by class_exists (6.0 branch)

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -92,7 +92,7 @@ class Runner extends \PHPUnit\TextUI\TestRunner
             $this->applyReporters($result, $arguments);
         }
 
-        if (class_exists('\Symfony\Bridge\PhpUnit\SymfonyTestsListener')) {
+        if (@class_exists('\Symfony\Bridge\PhpUnit\SymfonyTestsListener')) {
             $arguments['listeners'] = isset($arguments['listeners']) ? $arguments['listeners'] : [];
 
             $listener = new \Symfony\Bridge\PhpUnit\SymfonyTestsListener();


### PR DESCRIPTION
This issue affects my projects that are still using ZF1 with Zend_Loader