### PR TITLE
8.0 Use tests from Codeception 4.0 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-.idea
-composer.lock
-vendor
+/.idea
+/composer.lock
+/vendor
+/tests
+/codecept
+/codeception.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 env:
-  CODECEPTION_VERSION: '3.0.x-dev'
+  CODECEPTION_VERSION: '4.0.x-dev'
 
 php:
   - 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ before_script:
   - composer dump-autoload
 
 script:
-  - php ./codecept run cli
+  - php ./codecept run -c vendor/codeception/module-asserts/
   - php ./codecept run unit -g core
-  - php ./codecept run tests/unit/Codeception/Module/AssertsTest.php
+  - php ./codecept run cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,11 @@ php:
 
 before_script:
   - wget https://robo.li/robo.phar
-  - php robo.phar prepare
+  - php robo.phar prepare:dependencies
   - composer update
+  - php robo.phar prepare:tests
+  - php robo.phar prepare:test-autoloading
+  - composer dump-autoload
 
 script:
   - php ./codecept run cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - composer update
 
 script:
-  - php robo.phar test cli
-  - php robo.phar test "unit -g core"
-  - php robo.phar test "tests/unit/Codeception/Constraints/"
-  - php robo.phar test "tests/unit/Codeception/Module/AssertsTest.php"
+  - php ./codecept run cli
+  - php ./codecept run unit -g core
+  - php ./codecept run tests/unit/Codeception/Constraints/
+  - php ./codecept run tests/unit/Codeception/Module/AssertsTest.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,4 @@ before_script:
 script:
   - php ./codecept run cli
   - php ./codecept run unit -g core
-  - php ./codecept run tests/unit/Codeception/Constraints/
   - php ./codecept run tests/unit/Codeception/Module/AssertsTest.php

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -13,8 +13,7 @@ class RoboFile extends \Robo\Tasks
 
         $config['name'] = 'codeception/phpunit-wrapper-test';
         $config['require-dev']['codeception/codeception'] = getenv('CODECEPTION_VERSION');
-        $config['require-dev']['codeception/lib-innerbrowser'] = '*';
-        $config['require-dev']['codeception/module-asserts'] = '*';
+        $config['require-dev']['codeception/module-asserts'] = 'dev-master';
         $config['require-dev']['codeception/module-cli'] = '*';
         $config['require-dev']['codeception/module-db'] = '*';
         $config['require-dev']['codeception/module-filesystem'] = '*';

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -16,18 +16,15 @@ class RoboFile extends \Robo\Tasks
         $config['require-dev']['codeception/lib-innerbrowser'] = '*';
         $config['require-dev']['codeception/module-asserts'] = '*';
         $config['require-dev']['codeception/module-cli'] = '*';
+        $config['require-dev']['codeception/module-db'] = '*';
         $config['require-dev']['codeception/module-filesystem'] = '*';
         $config['require-dev']['codeception/module-phpbrowser'] = '*';
         $config['require-dev']['codeception/util-universalframework'] = '*';
         $config['replace'] = ['codeception/phpunit-wrapper' => '*'];
 
-        file_put_contents(__DIR__ . '/composer.json', json_encode($config));
-    }
-
-    public function test($params)
-    {
-        return $this->taskExec(__DIR__ . '/vendor/bin/codecept run ' . $params)
-            ->dir(__DIR__ .'/vendor/codeception/codeception')
-            ->run();
+        file_put_contents(__DIR__ . '/composer.json', json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        $this->_copyDir(__DIR__ . '/vendor/codeception/codeception/tests', __DIR__ . '/tests');
+        $this->_copy(__DIR__ . '/vendor/codeception/codeception/codeception.yml', __DIR__ .'/codeception.yml');
+        $this->_symlink(__DIR__ . '/vendor/bin/codecept', __DIR__ . '/codecept');
     }
 }

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -7,7 +7,7 @@
 class RoboFile extends \Robo\Tasks
 {
     // define public methods as commands
-    public function prepare()
+    public function prepareDependencies()
     {
         $config = json_decode(file_get_contents(__DIR__ . '/composer.json'), true);
 
@@ -23,8 +23,25 @@ class RoboFile extends \Robo\Tasks
         $config['replace'] = ['codeception/phpunit-wrapper' => '*'];
 
         file_put_contents(__DIR__ . '/composer.json', json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+
+    public function prepareTests()
+    {
         $this->_copyDir(__DIR__ . '/vendor/codeception/codeception/tests', __DIR__ . '/tests');
         $this->_copy(__DIR__ . '/vendor/codeception/codeception/codeception.yml', __DIR__ .'/codeception.yml');
         $this->_symlink(__DIR__ . '/vendor/bin/codecept', __DIR__ . '/codecept');
+    }
+
+    public function prepareTestAutoloading()
+    {
+        $config = json_decode(file_get_contents(__DIR__ . '/composer.json'), true);
+        $config['autoload-dev'] = [
+            'classmap' => [
+                'tests/cli/_steps',
+                'tests/data/DummyClass.php',
+                'tests/data/claypit/tests/_data'
+            ]
+        ];
+        file_put_contents(__DIR__ . '/composer.json', json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }
 }

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -13,6 +13,12 @@ class RoboFile extends \Robo\Tasks
 
         $config['name'] = 'codeception/phpunit-wrapper-test';
         $config['require-dev']['codeception/codeception'] = getenv('CODECEPTION_VERSION');
+        $config['require-dev']['codeception/lib-innerbrowser'] = '*';
+        $config['require-dev']['codeception/module-asserts'] = '*';
+        $config['require-dev']['codeception/module-cli'] = '*';
+        $config['require-dev']['codeception/module-filesystem'] = '*';
+        $config['require-dev']['codeception/module-phpbrowser'] = '*';
+        $config['require-dev']['codeception/util-universalframework'] = '*';
         $config['replace'] = ['codeception/phpunit-wrapper' => '*'];
 
         file_put_contents(__DIR__ . '/composer.json', json_encode($config));

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,6 @@
             "Codeception\\PHPUnit\\": "src/"
         }
     },
-    "autoload-dev": {
-        "classmap": [
-            "tests/cli/_steps",
-            "tests/data/DummyClass.php",
-            "tests/data/claypit/tests/_data"
-        ]
-    },
     "require-dev": {
         "vlucas/phpdotenv": "^3.0",
         "codeception/specify": "*"

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,17 @@
         "sebastian/comparator": "^3.0",
         "sebastian/diff": "^3.0"
     },
-    "autoload":{
-        "psr-4":{
+    "autoload": {
+        "psr-4": {
             "Codeception\\PHPUnit\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "classmap": [
+            "tests/cli/_steps",
+            "tests/data/DummyClass.php",
+            "tests/data/claypit/tests/_data"
+        ]
     },
     "require-dev": {
         "vlucas/phpdotenv": "^3.0",


### PR DESCRIPTION
The reason for this change is that Codeception `autoload` function was removed and replaced with composer.json `autoload-dev` section in 3.1.1: https://github.com/Codeception/Codeception/commit/42d055699fa5812ef10f7e31a4114b3ebdcf22f2#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780R70

I decided that it is easier to copy tests out of vendor directory than to get autoloading working for subdirectory of vendor dir.

(Please squash this PR)
