### PR TITLE
phpunit 9 compat fix

### DIFF
--- a/src/ResultPrinter/Report.php
+++ b/src/ResultPrinter/Report.php
@@ -53,7 +53,7 @@ class Report extends ResultPrinter implements ConsolePrinter
         ) . "\n");
     }
 
-    public function printResult(\PHPUnit\Framework\TestResult $result)
+    public function printResult(\PHPUnit\Framework\TestResult $result): void
     {
     }
 


### PR DESCRIPTION
seems like `printResult()` signature was updated in this commit/PR: https://github.com/Codeception/phpunit-wrapper/commit/3ee66da11374142f1548ab832a7892c5ff73e92a#diff-a127a35ad3427624ae102b25c4a9c435R98
but `Report` (that extends `ResultPrinter`) wasn't updated to reflect new signature. 