### PR TITLE
Revert "Fix error due to release of phpunit/php-code-coverage v9 (#5949)"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "phpunit/phpunit": "^9.0",
-        "phpunit/php-code-coverage": "^8.0"
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Reverts Codeception/phpunit-wrapper#81

Compatibility will be fixed in codeception/codeception by https://github.com/Codeception/Codeception/pull/5956