### PR TITLE
Fix broken UTF-8 in failure description of Page

### DIFF
--- a/src/Constraint/Page.php
+++ b/src/Constraint/Page.php
@@ -55,8 +55,8 @@ class Page extends \PHPUnit\Framework\Constraint\Constraint
     {
         $message = $this->uriMessage('on page');
         $message->append("\n--> ");
-        $message->append(substr($pageContent, 0, 300));
-        if (strlen($pageContent) > 300) {
+        $message->append(mb_substr($pageContent, 0, 300));
+        if (mb_strlen($pageContent) > 300) {
             $debugMessage = new Message(
                 "[Content too long to display. See complete response in '" . codecept_output_dir() . "' directory]"
             );


### PR DESCRIPTION
Use mb_* function instead.

Before:

![Bildschirmfoto von »2020-10-08 13-20-36«](https://user-images.githubusercontent.com/189796/95452236-3c21db80-0969-11eb-9e0f-659956b45bdd.png)

After:

![Bildschirmfoto von »2020-10-08 13-20-48«](https://user-images.githubusercontent.com/189796/95452249-417f2600-0969-11eb-8425-5cfaa61d2e9f.png)
