### PR TITLE
Use stdout stream for reports when available

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -139,7 +139,10 @@ class Runner extends NonFinal\TestRunner
         }
 
         if ($arguments['report']) {
-            self::$persistentListeners[] = $this->instantiateReporter('report');
+            self::$persistentListeners[] = $this->instantiateReporter(
+                'report',
+                [@fopen(STDOUT, 'w') ?: fopen('php://output', 'w')]
+            );
         }
 
         if ($arguments['html']) {

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -141,7 +141,7 @@ class Runner extends NonFinal\TestRunner
         if ($arguments['report']) {
             self::$persistentListeners[] = $this->instantiateReporter(
                 'report',
-                [@fopen(STDOUT, 'w') ?: fopen('php://output', 'w')]
+                [@STDOUT ?: fopen('php://output', 'w')]
             );
         }
 


### PR DESCRIPTION
Use stdout stream for reports when available. This avoids "Headers already sent" types of issues, when manipulating a session during testing.

When manipulating headers during acceptance testing, those tests would fail, if a report with output was activated. This could be the situation if running Codeception tests from PHPStorm.

A workaround is to use ob_start() in a bootstrap as described here https://stackoverflow.com/questions/31175636/headers-already-sent-running-unit-tests-in-phpstorm and here https://intellij-support.jetbrains.com/hc/en-us/community/posts/360000404160-Codeception-test-reports-Headers-already-sent-in-vendor-phpunit-phpunit-src-Util-Printer-php-on-line-109.

Using ob_start(), the user has to wait for all tests to complete, before the report-output is available.