### PR TITLE
Fix mb_stripos offset parameter for php 8.1

### DIFF
--- a/src/Constraint/Page.php
+++ b/src/Constraint/Page.php
@@ -25,7 +25,7 @@ class Page extends \PHPUnit\Framework\Constraint\Constraint
     protected function matches($other) : bool
     {
         $other = $this->normalizeText($other);
-        return mb_stripos($other, $this->string, null, 'UTF-8') !== false;
+        return mb_stripos($other, $this->string, 0, 'UTF-8') !== false;
     }
 
     /**


### PR DESCRIPTION
without this the method throws deprecation warning

`mb_stripos(): Passing null to parameter #3 ($offset) of type int is deprecated`